### PR TITLE
fix(sh): repair sudo, mutable default, and test gaps

### DIFF
--- a/docs/shell_commands.md
+++ b/docs/shell_commands.md
@@ -36,7 +36,7 @@ from nclutils.sh import run_command
 run_command("pwd", [], pushd=Path("/tmp"))
 ```
 
-If `pushd` points at a directory that doesn't exist, `run_command` raises `ShellCommandFailedError`.
+If `pushd` cannot be entered (missing, not a directory, or no permission), `run_command` raises `ShellCommandFailedError` with the underlying OS error in the message.
 
 ### Allowing non-zero exit codes
 
@@ -106,7 +106,7 @@ except ShellCommandFailedError as e:
     print(e.stderr)
 ```
 
-The exception is also raised when `pushd=` points at a missing directory; in that case the `e` attributes will be `None`.
+The exception is also raised when `pushd=` cannot be entered (missing, not a directory, or no permission). In that case the four attributes above are all `None` because no command actually ran; the underlying `OSError` is chained as `__cause__` and its description is included in the message.
 
 ## Looking up a command
 

--- a/docs/shell_commands.md
+++ b/docs/shell_commands.md
@@ -46,10 +46,10 @@ Some commands use exit codes as data — `grep` returns `1` when there are no ma
 from nclutils.sh import run_command
 
 # 0 (matched) and 1 (no match) are both fine; only 2+ raise
-run_command("grep", ["pattern", "file.txt"], okay_codes=[0, 1])
+run_command("grep", ["pattern", "file.txt"], okay_codes=(0, 1))
 ```
 
-`okay_codes` defaults to `[0]` when empty.
+`okay_codes` defaults to `(0,)`. An empty value falls back to `[0]`.
 
 ### Filtering output
 
@@ -64,9 +64,9 @@ run_command("npm", ["install"], exclude_regex=r"^npm warn deprecated")
 ### Other options
 
 - `quiet=True`. Collect output without printing it to the console.
-- `sudo=True`. Run under `sudo`. Uses `sh.contrib.sudo(k=True)`, which prompts once and caches credentials for the session.
-- `err_to_out=True` (the default). Fold stderr into stdout. Set to `False` to silence stderr entirely from the streamed output.
-- `fg=True`. Run the command in the foreground without capturing output. Use this for interactive commands like `vim` or `less`. The return value is an empty string.
+- `sudo=True`. Run under `sudo`. Requires either an interactive TTY for the password prompt or `NOPASSWD` configured in `sudoers`; will hang or fail in non-interactive contexts (CI, daemons) otherwise.
+- `err_to_out=True` (the default). Fold stderr into the captured stdout. Set to `False` to suppress stderr from both the streamed console output and the returned string.
+- `fg=True`. Run the command in the foreground without capturing output. Use this for interactive commands like `vim` or `less`. The return value is always an empty string.
 
 ## Errors
 
@@ -123,7 +123,7 @@ else:
 
 ## API reference
 
-- `run_command(cmd, args, pushd="", okay_codes=[], exclude_regex=None, *, quiet=False, sudo=False, err_to_out=True, fg=False) -> str`. Run a command and return its captured output.
+- `run_command(cmd, args, pushd="", okay_codes=(0,), exclude_regex=None, *, quiet=False, sudo=False, err_to_out=True, fg=False) -> str`. Run a command and return its captured output.
 - `which(cmd) -> str | None`. Resolve a command name to an absolute path, or `None`.
 - `ShellCommandFailedError`. Raised on non-zero exit. Exposes `exit_code`, `stdout`, `stderr`, `full_cmd`.
 - `ShellCommandNotFoundError`. Raised when the command isn't in `PATH`.

--- a/src/nclutils/sh/errors.py
+++ b/src/nclutils/sh/errors.py
@@ -1,65 +1,53 @@
 """Custom errors for script utilities."""
 
 
+def _decode(output: bytes | str | None) -> str | None:
+    """Decode subprocess output bytes to a stripped string.
+
+    Args:
+        output: Raw output from a subprocess (bytes), an already-decoded string, or None.
+
+    Returns:
+        str | None: The decoded and stripped output, or None if the input was None.
+    """
+    if output is None:
+        return None
+    if isinstance(output, bytes):
+        try:
+            return output.decode("utf-8").strip()
+        except UnicodeDecodeError:  # pragma: no cover
+            return str(output).strip()
+    return str(output).strip()
+
+
 class ShellCommandFailedError(Exception):
     """Raised when a shell command fails."""
 
     def __init__(self, msg: str | None = None, *, e: Exception | None = None) -> None:
-        self.exit_code: int | None = None
-        self.stderr: str | None = None
-        self.stdout: str | None = None
-        self.full_cmd: str | None = None
+        self.exit_code: int | None = getattr(e, "exit_code", None)
+        self.stderr: str | None = _decode(getattr(e, "stderr", None))
+        self.stdout: str | None = _decode(getattr(e, "stdout", None))
+        full_cmd = getattr(e, "full_cmd", None)
+        self.full_cmd: str | None = str(full_cmd).strip() if full_cmd is not None else None
 
-        msg = msg or "Shell command failed."
+        parts = [msg or "Shell command failed."]
+        if e is not None:
+            parts.append(f"Raised from: {e.__class__.__name__}: {e}")
+            if self.stderr:
+                parts.append(f"Stderr: {self.stderr}")
+            if self.stdout:
+                parts.append(f"Stdout: {self.stdout}")
+            if self.full_cmd:
+                parts.append(f"Full command: {self.full_cmd}")
 
-        if e:
-            msg += f"\nRaised from: {e.__class__.__name__}: {e}"
-
-            # Map error attributes to class attributes with proper decoding
-            attr_mapping = {
-                "exit_code": (lambda x: x, None),  # No decoding needed
-                "stderr": (self._decode_output, "Stderr"),
-                "stdout": (self._decode_output, "Stdout"),
-                "full_cmd": (lambda x: str(x).strip(), "Full command"),
-            }
-
-            for attr, (processor, label) in attr_mapping.items():
-                if hasattr(e, attr):
-                    value = getattr(e, attr)
-                    setattr(self, attr, processor(value))
-                    if label and getattr(
-                        self, attr
-                    ):  # Only add to message if we have a label and value
-                        msg += f"\n{label}: {getattr(self, attr)}"
-
-        super().__init__(msg)
-
-    @staticmethod
-    def _decode_output(output: bytes | str) -> str:
-        """Decode command output to string and strip whitespace.
-
-        Args:
-            output: The output to decode, either bytes or string
-
-        Returns:
-            str: The decoded and stripped output
-        """
-        if isinstance(output, bytes):
-            try:
-                return output.decode("utf-8").strip()
-            except UnicodeDecodeError:  # pragma: no cover
-                return str(output).strip()
-        return str(output).strip()
+        super().__init__("\n".join(parts))
 
 
 class ShellCommandNotFoundError(Exception):
     """Raised when a shell command is not found."""
 
     def __init__(self, msg: str | None = None, *, e: Exception | None = None) -> None:
-        if not msg:
-            msg = "Shell command not found."
-
-        if e:
-            msg += f"\nRaised from: {e.__class__.__name__}:\n{e}"
-
-        super().__init__(msg)
+        parts = [msg or "Shell command not found."]
+        if e is not None:
+            parts.append(f"Raised from: {e.__class__.__name__}:\n{e}")
+        super().__init__("\n".join(parts))

--- a/src/nclutils/sh/errors.py
+++ b/src/nclutils/sh/errors.py
@@ -4,13 +4,7 @@
 class ShellCommandFailedError(Exception):
     """Raised when a shell command fails."""
 
-    def __init__(
-        self,
-        msg: str | None = None,
-        e: Exception | None = None,
-        *args: str | int,
-        **kwargs: int | str | bool,
-    ):
+    def __init__(self, msg: str | None = None, *, e: Exception | None = None) -> None:
         self.exit_code: int | None = None
         self.stderr: str | None = None
         self.stdout: str | None = None
@@ -38,7 +32,7 @@ class ShellCommandFailedError(Exception):
                     ):  # Only add to message if we have a label and value
                         msg += f"\n{label}: {getattr(self, attr)}"
 
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg)
 
     @staticmethod
     def _decode_output(output: bytes | str) -> str:
@@ -61,17 +55,11 @@ class ShellCommandFailedError(Exception):
 class ShellCommandNotFoundError(Exception):
     """Raised when a shell command is not found."""
 
-    def __init__(
-        self,
-        msg: str | None = None,
-        e: Exception | None = None,
-        *args: str | int,
-        **kwargs: int | str | bool,
-    ):
+    def __init__(self, msg: str | None = None, *, e: Exception | None = None) -> None:
         if not msg:
             msg = "Shell command not found."
 
         if e:
             msg += f"\nRaised from: {e.__class__.__name__}:\n{e}"
 
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg)

--- a/src/nclutils/sh/errors.py
+++ b/src/nclutils/sh/errors.py
@@ -2,14 +2,7 @@
 
 
 def _decode(output: bytes | str | None) -> str | None:
-    """Decode subprocess output bytes to a stripped string.
-
-    Args:
-        output: Raw output from a subprocess (bytes), an already-decoded string, or None.
-
-    Returns:
-        str | None: The decoded and stripped output, or None if the input was None.
-    """
+    """Decode subprocess output (bytes/str/None) to a stripped string or None."""
     if output is None:
         return None
     if isinstance(output, bytes):
@@ -27,8 +20,7 @@ class ShellCommandFailedError(Exception):
         self.exit_code: int | None = getattr(e, "exit_code", None)
         self.stderr: str | None = _decode(getattr(e, "stderr", None))
         self.stdout: str | None = _decode(getattr(e, "stdout", None))
-        full_cmd = getattr(e, "full_cmd", None)
-        self.full_cmd: str | None = str(full_cmd).strip() if full_cmd is not None else None
+        self.full_cmd: str | None = _decode(getattr(e, "full_cmd", None))
 
         parts = [msg or "Shell command failed."]
         if e is not None:

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -27,12 +27,12 @@ def which(cmd: str) -> str | None:
     """
     try:
         result = sh.which(cmd)
-    except sh.CommandNotFound:  # pragma: no cover
-        return None
-    except sh.ErrorReturnCode:
+    except (sh.CommandNotFound, sh.ErrorReturnCode):
+        # `sh.which` shells out to /usr/bin/which, which exits 1 when the command is
+        # missing. CommandNotFound covers the case where /usr/bin/which itself is gone.
         return None
 
-    if result is None:  # pragma: no cover
+    if result is None:
         return None
 
     return str(result).strip()
@@ -42,7 +42,7 @@ def run_command(  # noqa: C901, PLR0913
     cmd: str,
     args: list[str],
     pushd: str | Path = "",
-    okay_codes: list[int] = [],
+    okay_codes: tuple[int, ...] = (0,),
     exclude_regex: str | None = None,
     *,
     quiet: bool = False,
@@ -58,15 +58,15 @@ def run_command(  # noqa: C901, PLR0913
         cmd (str): The command name to execute
         args (list[str]): Command line arguments to pass to the command
         pushd (str | Path): Directory to change to before running the command. Empty string means current directory. Defaults to "".
-        okay_codes (list[int]): List of exit codes that are considered successful. Defaults to [].
+        okay_codes (tuple[int, ...]): Exit codes that are considered successful. Defaults to (0,).
         exclude_regex (str | None): Regex to exclude lines from the output. Defaults to None.
         quiet (bool): Whether to suppress real-time output to console. Defaults to False.
-        sudo (bool): Whether to run the command with sudo. Defaults to False.
-        err_to_out (bool): Whether to redirect stderr to stdout. Defaults to True.
-        fg (bool): Whether to run the command in foreground. Defaults to False
+        sudo (bool): Whether to run the command with sudo. Requires either an interactive TTY for the password prompt or NOPASSWD configured in sudoers; will hang or fail in non-interactive contexts otherwise. Defaults to False.
+        err_to_out (bool): Whether to fold stderr into the captured stdout. When False, stderr is suppressed from both the streamed console output and the returned string. Defaults to True.
+        fg (bool): Whether to run the command in foreground without capturing output. Returns an empty string when True; use this for interactive commands like vim or less. Defaults to False.
 
     Returns:
-        str: The complete command output as a string with ANSI color codes preserved
+        str: The complete command output as a string with ANSI color codes preserved, or an empty string when fg=True
 
     Raises:
         ShellCommandNotFoundError: When the command is not found in PATH
@@ -108,30 +108,25 @@ def run_command(  # noqa: C901, PLR0913
         # Build kwargs conditionally
         cmd_kwargs: dict[str, Any] = {}
 
+        ok_code = list(okay_codes) or [0]
         if fg:
-            cmd_kwargs.update(
-                {
-                    "_fg": True,
-                    "_ok_code": okay_codes or [0],
-                }
-            )
+            cmd_kwargs.update({"_fg": True, "_ok_code": ok_code})
         else:
             # Only add these kwargs when NOT in foreground mode
             cmd_kwargs.update(
                 {
-                    "_err": lambda line: (
-                        _process_output(line, exclude_regex) if err_to_out else None
-                    ),
                     "_out": lambda line: _process_output(line, exclude_regex),
-                    "_ok_code": okay_codes or [0],
+                    "_ok_code": ok_code,
                     "_tee": "err",
                 }
             )
+            if err_to_out:
+                cmd_kwargs["_err"] = lambda line: _process_output(line, exclude_regex)
 
         try:
             command = sh.Command(cmd)
             if sudo:
-                with sh.contrib.sudo(k=True, _with=True):
+                with sh.contrib.sudo(_with=True):
                     command(*args, **cmd_kwargs)
             else:
                 command(*args, **cmd_kwargs)
@@ -145,14 +140,15 @@ def run_command(  # noqa: C901, PLR0913
     if pushd:
         if not isinstance(pushd, Path):
             pushd = Path(pushd)
-
         pushd = pushd.expanduser().absolute()
 
-        if not pushd.exists():
+        try:
+            with sh.pushd(pushd):
+                return _execute_command(sudo=sudo)
+        except OSError as e:
+            # chdir-time failures (missing dir, not-a-directory, permission) — surface
+            # as ShellCommandFailedError so callers don't get raw OSError.
             msg = f"Directory {pushd} does not exist"
-            raise ShellCommandFailedError(msg)
-
-        with sh.pushd(pushd):
-            return _execute_command(sudo=sudo)
+            raise ShellCommandFailedError(msg, e=e) from e
 
     return _execute_command(sudo=sudo)

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -81,9 +81,9 @@ def run_command(  # noqa: C901, PLR0913
     def _on_line(line: str) -> None:
         if exclude_pattern is not None and exclude_pattern.search(line):
             return
-        output_lines.append(str(line))
+        output_lines.append(line)
         if not quiet:
-            console.print(Text.from_ansi(str(line)))
+            console.print(Text.from_ansi(line))
 
     def _execute() -> str:
         ok_code = list(okay_codes) or [0]
@@ -97,6 +97,9 @@ def run_command(  # noqa: C901, PLR0913
         try:
             command = sh.Command(cmd)
             if sudo:
+                # Do NOT pass `k=True` — that would invalidate cached sudo credentials
+                # before each invocation, forcing a password prompt every call and
+                # hanging in non-interactive contexts (CI, daemons).
                 with sh.contrib.sudo(_with=True):
                     command(*args, **cmd_kwargs)
             else:
@@ -116,9 +119,10 @@ def run_command(  # noqa: C901, PLR0913
             with sh.pushd(pushd):
                 return _execute()
         except OSError as e:
-            # chdir-time failures (missing dir, not-a-directory, permission) — surface
+            # Surface chdir-time failures (missing dir, not-a-directory, permission)
             # as ShellCommandFailedError so callers don't get raw OSError.
-            msg = f"Directory {pushd} does not exist"
+            detail = e.strerror or str(e)
+            msg = f"Cannot enter directory {pushd}: {detail}"
             raise ShellCommandFailedError(msg, e=e) from e
 
     return _execute()

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -5,12 +5,11 @@ from pathlib import Path
 from typing import Any
 
 import sh
-from rich.console import Console
 from rich.text import Text
 
-from .errors import ShellCommandFailedError, ShellCommandNotFoundError
+from nclutils.pretty_print import console as get_console
 
-console = Console()
+from .errors import ShellCommandFailedError, ShellCommandNotFoundError
 
 
 def which(cmd: str) -> str | None:
@@ -73,55 +72,27 @@ def run_command(  # noqa: C901, PLR0913
         ShellCommandFailedError: When the command exits with a non-zero status code
     """
     output_lines: list[str] = []
+    # Compile once instead of per-line — significant for high-volume output.
+    exclude_pattern = re.compile(exclude_regex) if exclude_regex else None
+    # Resolve the shared pretty_print console once per call so set_default()
+    # swaps in the host application still take effect between invocations.
+    console = get_console()
 
-    def _process_output(line: str, exclude_regex: str | None = None) -> None:
-        """Process a single line of command output.
-
-        Collect output lines for final return value and optionally display to console. Preserve ANSI color codes and formatting when displaying output.
-
-        Args:
-            line (str): A single line of output from the command execution
-            exclude_regex (str | None): Regex to exclude lines from the output. Defaults to None.
-        """
-        if exclude_regex and re.search(exclude_regex, line):
+    def _on_line(line: str) -> None:
+        if exclude_pattern is not None and exclude_pattern.search(line):
             return
-
         output_lines.append(str(line))
         if not quiet:
             console.print(Text.from_ansi(str(line)))
 
-    def _execute_command(*, sudo: bool = False) -> str:
-        """Execute the shell command and process its output.
-
-        Create and run the shell command with the configured arguments. Handle command execution errors by raising appropriate exceptions.
-
-        Args:
-            sudo (bool): Whether to run the command with sudo. Defaults to False.
-
-        Returns:
-            str: The complete command output as a string
-
-        Raises:
-            ShellCommandNotFoundError: When the command is not found in PATH
-            ShellCommandFailedError: When the command exits with a non-zero status code
-        """
-        # Build kwargs conditionally
-        cmd_kwargs: dict[str, Any] = {}
-
+    def _execute() -> str:
         ok_code = list(okay_codes) or [0]
         if fg:
-            cmd_kwargs.update({"_fg": True, "_ok_code": ok_code})
+            cmd_kwargs: dict[str, Any] = {"_fg": True, "_ok_code": ok_code}
         else:
-            # Only add these kwargs when NOT in foreground mode
-            cmd_kwargs.update(
-                {
-                    "_out": lambda line: _process_output(line, exclude_regex),
-                    "_ok_code": ok_code,
-                    "_tee": "err",
-                }
-            )
+            cmd_kwargs = {"_out": _on_line, "_ok_code": ok_code, "_tee": "err"}
             if err_to_out:
-                cmd_kwargs["_err"] = lambda line: _process_output(line, exclude_regex)
+                cmd_kwargs["_err"] = _on_line
 
         try:
             command = sh.Command(cmd)
@@ -130,7 +101,6 @@ def run_command(  # noqa: C901, PLR0913
                     command(*args, **cmd_kwargs)
             else:
                 command(*args, **cmd_kwargs)
-
             return "".join(output_lines)
         except sh.CommandNotFound as e:
             raise ShellCommandNotFoundError(e=e) from e
@@ -144,11 +114,11 @@ def run_command(  # noqa: C901, PLR0913
 
         try:
             with sh.pushd(pushd):
-                return _execute_command(sudo=sudo)
+                return _execute()
         except OSError as e:
             # chdir-time failures (missing dir, not-a-directory, permission) — surface
             # as ShellCommandFailedError so callers don't get raw OSError.
             msg = f"Directory {pushd} does not exist"
             raise ShellCommandFailedError(msg, e=e) from e
 
-    return _execute_command(sudo=sudo)
+    return _execute()

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -216,7 +216,7 @@ def test_run_command_with_pushd_nonexistent_dir(capsys: pytest.CaptureFixture) -
     cmd = "pwd"
 
     # When/Then: Running command with invalid pushd raises error
-    with pytest.raises(ShellCommandFailedError, match=r"Directory.*does not exist"):
+    with pytest.raises(ShellCommandFailedError, match=r"Cannot enter directory"):
         run_command(cmd, [], pushd=nonexistent_dir)
 
     captured = capsys.readouterr()
@@ -287,37 +287,33 @@ def test_run_command_fg_passes_fg_kwarg_to_sh(mocker: MockerFixture) -> None:
     assert "_tee" not in call_kwargs
 
 
-def test_run_command_with_sudo_enters_sudo_context(mocker: MockerFixture) -> None:
-    """Verify sudo=True wraps execution in sh.contrib.sudo(_with=True)."""
-    # Given: sh.contrib is replaced with a MagicMock (sh.contrib.sudo is a property
-    # so it cannot be patched directly); sh.Command is stubbed so no real process runs
+@pytest.fixture
+def stub_sh(mocker: MockerFixture):
+    """Stub sh.contrib (a property — can't patch sh.contrib.sudo directly) and sh.Command."""
     fake_contrib = mocker.MagicMock()
     mocker.patch("nclutils.sh.shell_command.sh.contrib", new=fake_contrib)
     mocker.patch("nclutils.sh.shell_command.sh.Command")
+    return fake_contrib
 
+
+def test_run_command_with_sudo_enters_sudo_context(stub_sh) -> None:
+    """Verify sudo=True wraps execution in sh.contrib.sudo(_with=True)."""
     # When: Running with sudo=True
     run_command("echo", ["hello"], sudo=True, quiet=True)
 
-    # Then: sudo was invoked with _with=True (and notably WITHOUT k=True, which
-    # would invalidate cached credentials before each call) and was entered
-    fake_contrib.sudo.assert_called_once_with(_with=True)
-    fake_contrib.sudo.return_value.__enter__.assert_called_once()
+    # Then: sudo was invoked with _with=True and entered as a context manager.
+    # The absence of k=True is enforced by assert_called_once_with's exact-match.
+    stub_sh.sudo.assert_called_once_with(_with=True)
+    stub_sh.sudo.return_value.__enter__.assert_called_once()
 
 
-def test_run_command_without_sudo_does_not_enter_sudo_context(
-    mocker: MockerFixture,
-) -> None:
+def test_run_command_without_sudo_does_not_enter_sudo_context(stub_sh) -> None:
     """Verify sudo=False leaves sh.contrib.sudo untouched."""
-    # Given: sh.contrib is replaced with a MagicMock and sh.Command is stubbed
-    fake_contrib = mocker.MagicMock()
-    mocker.patch("nclutils.sh.shell_command.sh.contrib", new=fake_contrib)
-    mocker.patch("nclutils.sh.shell_command.sh.Command")
-
     # When: Running without sudo
     run_command("echo", ["hello"], quiet=True)
 
     # Then: sudo was never invoked
-    fake_contrib.sudo.assert_not_called()
+    stub_sh.sudo.assert_not_called()
 
 
 def test_run_command_err_to_out_false_drops_successful_stderr(

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from nclutils.sh import (
     ShellCommandFailedError,
@@ -242,3 +243,97 @@ def test_exclude_lines(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     assert "working... 0%" not in str(output)
     assert "working... 10%" not in str(output)
     assert "done" in str(output)
+
+
+@pytest.mark.parametrize(
+    ("codes", "should_raise"),
+    [
+        ((0, 1), False),
+        ((0,), True),
+    ],
+)
+def test_run_command_okay_codes_whitelist(codes: tuple[int, ...], *, should_raise: bool) -> None:
+    """Verify okay_codes whitelists non-zero exit codes."""
+    # Given: A grep that exits 1 because no line matches
+    cmd = "grep"
+    args = ["pattern_that_will_not_match", "/dev/null"]
+
+    # When/Then: The exit code raises only when not in okay_codes
+    if should_raise:
+        with pytest.raises(ShellCommandFailedError) as excinfo:
+            run_command(cmd, args, okay_codes=codes, quiet=True)
+        assert excinfo.value.exit_code == 1
+    else:
+        result = run_command(cmd, args, okay_codes=codes, quiet=True)
+        assert result == ""
+
+
+def test_run_command_fg_passes_fg_kwarg_to_sh(mocker: MockerFixture) -> None:
+    """Verify fg=True forwards _fg=True to sh.Command and skips capture kwargs."""
+    # Given: sh.Command is mocked so the underlying invocation is intercepted
+    mock_cmd_class = mocker.patch("nclutils.sh.shell_command.sh.Command")
+
+    # When: Running with fg=True
+    run_command("echo", ["test"], fg=True)
+
+    # Then: The command was called with _fg=True and without capture callbacks
+    mock_cmd_class.assert_called_once_with("echo")
+    cmd_instance = mock_cmd_class.return_value
+    cmd_instance.assert_called_once()
+    call_kwargs = cmd_instance.call_args.kwargs
+    assert call_kwargs.get("_fg") is True
+    assert "_out" not in call_kwargs
+    assert "_err" not in call_kwargs
+    assert "_tee" not in call_kwargs
+
+
+def test_run_command_with_sudo_enters_sudo_context(mocker: MockerFixture) -> None:
+    """Verify sudo=True wraps execution in sh.contrib.sudo(_with=True)."""
+    # Given: sh.contrib is replaced with a MagicMock (sh.contrib.sudo is a property
+    # so it cannot be patched directly); sh.Command is stubbed so no real process runs
+    fake_contrib = mocker.MagicMock()
+    mocker.patch("nclutils.sh.shell_command.sh.contrib", new=fake_contrib)
+    mocker.patch("nclutils.sh.shell_command.sh.Command")
+
+    # When: Running with sudo=True
+    run_command("echo", ["hello"], sudo=True, quiet=True)
+
+    # Then: sudo was invoked with _with=True (and notably WITHOUT k=True, which
+    # would invalidate cached credentials before each call) and was entered
+    fake_contrib.sudo.assert_called_once_with(_with=True)
+    fake_contrib.sudo.return_value.__enter__.assert_called_once()
+
+
+def test_run_command_without_sudo_does_not_enter_sudo_context(
+    mocker: MockerFixture,
+) -> None:
+    """Verify sudo=False leaves sh.contrib.sudo untouched."""
+    # Given: sh.contrib is replaced with a MagicMock and sh.Command is stubbed
+    fake_contrib = mocker.MagicMock()
+    mocker.patch("nclutils.sh.shell_command.sh.contrib", new=fake_contrib)
+    mocker.patch("nclutils.sh.shell_command.sh.Command")
+
+    # When: Running without sudo
+    run_command("echo", ["hello"], quiet=True)
+
+    # Then: sudo was never invoked
+    fake_contrib.sudo.assert_not_called()
+
+
+def test_run_command_err_to_out_false_drops_successful_stderr(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Verify err_to_out=False suppresses stderr from a successful command."""
+    # Given: A successful command emitting both stdout and stderr
+    cmd = "sh"
+    args = ["-c", "echo OUTLINE; echo ERRLINE >&2"]
+
+    # When: Running with err_to_out=False
+    output = run_command(cmd, args, err_to_out=False)
+
+    # Then: stderr is absent from both the captured return value and the streamed console
+    assert "OUTLINE" in output
+    assert "ERRLINE" not in output
+    captured = capsys.readouterr()
+    assert "OUTLINE" in captured.out
+    assert "ERRLINE" not in captured.out


### PR DESCRIPTION
## Summary

Fix the most painful bugs in `nclutils.sh`, refactor for clarity, close real test-coverage gaps, and bring docs back in sync. All on one module; squash-friendly.

### Bugs (real misbehavior)
- **`sh.contrib.sudo(k=True)`** was passing `-K` to sudo, *invalidating* the cached credential before each call — guaranteed prompt every invocation, hangs in CI/containers. Drop `k=True`.
- **`okay_codes: list[int] = []`** mutable default (B006) → `tuple[int, ...] = (0,)`.
- **Both exception classes** advertised `**kwargs` and forwarded them to `Exception.__init__`, which raises `TypeError`. Make `e` keyword-only and drop the bogus passthrough.
- **`sh.pushd` TOCTOU**: `exists()` then `chdir()` could race; raw `OSError` propagated past the wrapper. Catch all `OSError` and re-raise as `ShellCommandFailedError` with the underlying `e.strerror` in the message.
- **Docstrings** corrected for `fg=True` (always returns `""`) and `err_to_out=False` (suppresses stderr from both stream and capture, not just stream).

### Refactor (clarity)
- Replace the `attr_mapping` dict-driven extraction in `ShellCommandFailedError` with explicit assignments + `"\n".join(parts)`.
- Hoist `_decode` to module scope; route `full_cmd` through it instead of bespoke `str(...).strip()`.
- Pre-compile `exclude_regex` once per call instead of per output line.
- Reuse `pretty_print`'s shared `console` (the project's designated Rich owner) instead of a private module-level `Console()`.
- Drop redundant `str(line)` casts in the per-line hot path (`sh._out` already delivers `str`).
- Inline closures renamed (`_on_line`, `_execute`); their docstrings dropped in favor of the names carrying intent.

### Tests (+6, 262 → 268)
- `okay_codes` whitelist (parametrized `grep` exit-1 case) — the headline feature was untested.
- `fg=True` plumbing: assert `_fg=True` reaches `sh.Command` and capture kwargs are absent.
- `sudo=True` enters `sh.contrib.sudo(_with=True)`; `assert_called_once_with` exact-match pins out any future `k=True` regression.
- `sudo=False` doesn't touch `sh.contrib.sudo`.
- `err_to_out=False` on a successful command emitting stderr — the silent-data-loss case the prior tests didn't catch.
- Shared `stub_sh` fixture dedupes the `sh.contrib`/`sh.Command` patch dance.

### Docs
- `docs/shell_commands.md` updated for the new `okay_codes` default, the corrected `sudo`/`err_to_out`/`fg` semantics, the broader pushd error story, and the new API-reference signature.

### Out of scope (deferred to a future 3.0)
- Single-argv-list signature (`run_command(["git", "status"])`).
- `CompletedCommand`-style structured return instead of bare `str`.
- Flipping `quiet` default to `True` (library functions shouldn't print by default).
- Shared `ShellCommandError` base class.
- `which() -> Path | None`.
- Streaming/iterator API for unbounded output.

## Test plan

- [x] `uv run pytest` — 268 pass (was 262)
- [x] `uv run mypy --config-file=pyproject.toml src/nclutils/sh/` — clean
- [x] `uv run ruff check` — clean
- [x] All pre-commit hooks pass
- [ ] Manually exercise `run_command("sudo", ["-l"], sudo=True)` on a host with cached sudo creds to confirm no re-prompt (cannot verify in CI)