### PR TITLE
feat(sh)!: redesign shell module on subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ from nclutils.utils import iso_timestamp, unique_id
 
 ## Modules
 
-The larger modules have their own documentation pages. Smaller modules are listed inline below. Function signatures live with the source — consult docstrings (`help(func)` or your editor's hover) for authoritative argument details.
+The larger modules have their own documentation pages. Smaller modules are listed inline below. Function signatures live with the source; consult docstrings (`help(func)` or your editor's hover) for authoritative argument details.
 
 | Module                    | Summary                                                  | Docs                                  |
 | ------------------------- | -------------------------------------------------------- | ------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ uv add nclutils
 pip install nclutils
 ```
 
-The package brings in three runtime dependencies: [questionary](https://github.com/tmbo/questionary), [rich](https://github.com/Textualize/rich), and [sh](https://github.com/amoffat/sh).
+The package brings in two runtime dependencies: [questionary](https://github.com/tmbo/questionary) and [rich](https://github.com/Textualize/rich).
 
 ## Importing
 
@@ -53,7 +53,7 @@ Everything else lives in its submodule and must be imported from there:
 from nclutils.fs import copy_file, find_files
 from nclutils.network import network_available
 from nclutils.questions import choose_one_from_list
-from nclutils.sh import run_command, ShellCommandFailedError
+from nclutils.sh import run_command, run_interactive, which, CompletedCommand, ShellCommandError
 from nclutils.strings import camel_case, deburr
 from nclutils.text_processing import replace_in_file
 from nclutils.utils import iso_timestamp, unique_id
@@ -69,7 +69,7 @@ The larger modules have their own documentation pages. Smaller modules are liste
 | `nclutils.network`        | Lightweight network reachability check.                  | _(inline below)_                      |
 | `nclutils.pretty_print`   | Rich-based console output, verbosity gates, file logger. | [docs/pretty_print.md](docs/pretty_print.md) |
 | `nclutils.questions`      | Single- and multi-select prompts via `questionary`.      | [docs/questions.md](docs/questions.md) |
-| `nclutils.sh`             | Run shell commands with streamed output and typed errors. | [docs/shell_commands.md](docs/shell_commands.md) |
+| `nclutils.sh`             | Run commands via subprocess; returns `CompletedCommand`, raises typed errors (`ShellCommandError` hierarchy). Includes `run_command`, `run_interactive`, `which`. | [docs/shell_commands.md](docs/shell_commands.md) |
 | `nclutils.strings`        | Case conversions, padding, tokenizing, normalization.    | [docs/strings.md](docs/strings.md)    |
 | `nclutils.text_processing` | In-place file edits.                                    | _(inline below)_                      |
 | `nclutils.utils`          | Timestamps, unique IDs, Python version check.            | [docs/utils.md](docs/utils.md)        |

--- a/docs/fs.md
+++ b/docs/fs.md
@@ -33,9 +33,11 @@ copy_file(src, dst, keep_backup=False)
 
 `with_progress=True` shows a Rich progress bar; `transient=True` (the default) clears the bar after the copy completes.
 
-> **Note:** `copy_directory` requires Python 3.12+ because it uses `Path.walk()`. Calling it on an older interpreter raises `ValueError`.
+> [!NOTE]
+> `copy_directory` requires Python 3.12+ because it uses `Path.walk()`. Calling it on an older interpreter raises `ValueError`.
 
-> **Warning:** Refusing to copy is silent. Same source and destination, or copying a directory into itself or its parent, returns the source path and logs a warning rather than raising. Check the return value or watch the `nclutils.fs` logger if this matters.
+> [!WARNING]
+> Refusing to copy is silent. Same source and destination, or copying a directory into itself or its parent, returns the source path and logs a warning rather than raising. Check the return value or watch the `nclutils.fs` logger if this matters.
 
 ## Standalone backups
 
@@ -58,7 +60,7 @@ By default `backup_path` returns `None` when the source doesn't exist. Pass `rai
 
 ## Cleaning a directory
 
-`clean_directory` empties a directory in place — files are unlinked and subdirectories are removed recursively, but the directory itself stays.
+`clean_directory` empties a directory in place: files are unlinked and subdirectories are removed recursively, but the directory itself stays.
 
 ```python
 from pathlib import Path
@@ -157,7 +159,7 @@ logging.getLogger("nclutils.fs").setLevel(logging.DEBUG)
 logging.basicConfig()
 ```
 
-This is independent of `nclutils.pretty_print` — it covers internal operations like "starting a copy" or "skipping a backup because the source is missing."
+This is independent of `nclutils.pretty_print`. It covers internal operations like "starting a copy" or "skipping a backup because the source is missing."
 
 ## API reference
 

--- a/docs/pretty_print.md
+++ b/docs/pretty_print.md
@@ -145,7 +145,8 @@ with step("warming caches", ephemeral=True) as s:
 # success leaves no trace; failure still prints "✗ warming caches"
 ```
 
-> **Warning:** `step()` cannot nest. Rich's `Live` doesn't stack, so nesting silently corrupts the parent's display. `pretty_print` raises `RuntimeError` when you try.
+> [!WARNING]
+> `step()` cannot nest. Rich's `Live` doesn't stack, so nesting silently corrupts the parent's display. `pretty_print` raises `RuntimeError` when you try.
 
 ## File logging
 
@@ -275,7 +276,8 @@ e.info("captured")
 assert "captured" in capture.export_text()
 ```
 
-> **Note:** Use the `theme=` argument to customize level styles, not a custom `Console(theme=...)`. Level styles are resolved inline at print time, so a theme dict on a user-supplied `Console` no longer overrides level rendering.
+> [!NOTE]
+> Use the `theme=` argument to customize level styles, not a custom `Console(theme=...)`. Level styles are resolved inline at print time, so a theme dict on a user-supplied `Console` no longer overrides level rendering.
 >
 > The `Console(theme=THEME)` pattern is still valid when you need to capture the default theme's structural styles (`header`, `header.rule`, `sub.pipe`) on your own console.
 

--- a/docs/questions.md
+++ b/docs/questions.md
@@ -91,7 +91,8 @@ selected = choose_multiple_from_list(
 # -> ["fe", "be"] (or whichever boxes the user checked)
 ```
 
-> **Note:** Mixing shapes in the same call works (each item is inspected independently), but it's a smell. Pick one shape per prompt.
+> [!NOTE]
+> Mixing shapes in the same call works (each item is inspected independently), but it's a smell. Pick one shape per prompt.
 
 ## API reference
 

--- a/docs/shell_commands.md
+++ b/docs/shell_commands.md
@@ -1,6 +1,6 @@
 # Shell commands
 
-A thin wrapper over stdlib `subprocess` for running external commands. Imported from `nclutils.sh`. Results come back as a typed `CompletedCommand` dataclass rather than raw strings, and every failure mode maps to a specific exception class. Output goes to `sys.stdout`/`sys.stderr` directly — `nclutils.sh` does not route through `nclutils.pretty_print`'s console.
+A thin wrapper over stdlib `subprocess` for running external commands. Imported from `nclutils.sh`. Results come back as a typed `CompletedCommand` dataclass rather than raw strings, and every failure mode maps to a specific exception class. Output goes to `sys.stdout`/`sys.stderr` directly; `nclutils.sh` does not route through `nclutils.pretty_print`'s console.
 
 ```python
 from pathlib import Path
@@ -49,11 +49,12 @@ result = run_command(["rsync", "-av", "src/", "dst/"], stream=True)
 print(f"finished in {result.duration:.1f}s")
 ```
 
-> **Note:** stdout and stderr are drained by separate threads, so within each stream lines stay in order, but the relative interleaving between stdout and stderr is not deterministic. If you need true chronological interleaving, run the command via `sh -c "... 2>&1"` and inspect `result.stdout`.
+> [!NOTE]
+> stdout and stderr are drained by separate threads. Within each stream lines stay in order, but the relative interleaving between stdout and stderr is not deterministic. For true chronological interleaving, run the command via `sh -c "... 2>&1"` and inspect `result.stdout`.
 
 ## Options
 
-### `cwd=` — working directory
+### `cwd=`: working directory
 
 Pass a `Path` or `str` to run the command from a different directory. `None` (the default) inherits the parent process's working directory.
 
@@ -64,9 +65,9 @@ from nclutils.sh import run_command
 result = run_command(["pwd"], cwd=Path("/tmp"))
 ```
 
-If `cwd` cannot be entered — missing, not a directory, or no permission — `run_command` raises `ShellCommandFailedError` before the process starts (`result` will be `None` on that exception).
+If `cwd` cannot be entered (missing, not a directory, or no permission), `run_command` raises `ShellCommandFailedError` before the process starts. `result` is `None` on that exception because no command actually ran.
 
-### `env=` — environment variables
+### `env=`: environment variables
 
 When `env=` is provided it *replaces* the child's entire environment. To extend the current environment, merge it explicitly:
 
@@ -82,7 +83,7 @@ result = run_command(
 
 Passing `env=None` (the default) inherits the parent's environment unchanged.
 
-### `input=` — stdin
+### `input=`: stdin
 
 Pass a string or bytes to write to the child's stdin:
 
@@ -93,9 +94,10 @@ result = run_command(["wc", "-w"], input="hello world")
 print(result.stdout.strip())  # "2"
 ```
 
-For large inputs (>64 KB) where the child also produces output, a deadlock is possible because stdin is fully written before stdout starts draining. Use shell redirection in that case.
+> [!WARNING]
+> For inputs over ~64 KB where the child also produces output, a deadlock is possible because stdin is fully written before stdout starts draining. Pipe via shell redirection in that case (e.g., `run_command(["sh", "-c", "cat large.txt | wc -l"])`).
 
-### `timeout=` — time limit
+### `timeout=`: time limit
 
 Pass a number of seconds. If the process runs longer, it is killed and `ShellCommandTimeoutError` is raised:
 
@@ -109,7 +111,7 @@ except ShellCommandTimeoutError as e:
     print(f"partial stdout: {e.result.stdout!r}")
 ```
 
-### `exclude_regex=` — filter lines
+### `exclude_regex=`: filter lines
 
 Lines matching this regex are dropped from both the streamed output and the captured strings. Useful for suppressing noisy warnings:
 
@@ -119,7 +121,7 @@ from nclutils.sh import run_command
 run_command(["npm", "install"], stream=True, exclude_regex=r"^npm warn deprecated")
 ```
 
-### `check=False` — skip failure check
+### `check=False`: skip failure check
 
 By default `run_command` raises `ShellCommandFailedError` on any non-zero exit. Pass `check=False` to suppress this and inspect the return code yourself:
 
@@ -130,7 +132,7 @@ result = run_command(["false"], check=False)
 print(result.returncode)  # 1
 ```
 
-### `okay_codes=` — acceptable exit codes
+### `okay_codes=`: acceptable exit codes
 
 Some commands use non-zero exits as data. `grep` returns `1` when no lines match; `diff` returns `1` for non-identical files. Pass `okay_codes=` to treat additional codes as success:
 
@@ -144,9 +146,9 @@ result = run_command(
 )
 ```
 
-### `sudo=True` — run as root
+### `sudo=True`: run as root
 
-Prepends `["sudo"]` to the argument list. Cached credentials are used; `sudo -k` is never called. This requires an interactive TTY for the password prompt or `NOPASSWD` in sudoers — it will hang or fail in non-interactive contexts such as CI.
+Prepends `["sudo"]` to the argument list. Cached credentials are used; `sudo -k` is never called. Either an interactive TTY (for the password prompt) or `NOPASSWD` in sudoers is required. The call will hang or fail in non-interactive contexts such as CI.
 
 ```python
 from nclutils.sh import run_command
@@ -218,7 +220,7 @@ except ShellCommandTimeoutError as e:
 
 ## Interactive commands
 
-Use `run_interactive` for commands that need a real terminal — editors, pagers, SSH sessions, anything that drives the terminal directly. The child inherits stdin, stdout, and stderr from the parent; nothing is captured.
+Use `run_interactive` for commands that need a real terminal: editors, pagers, SSH sessions, anything that drives the terminal directly. The child inherits stdin, stdout, and stderr from the parent; nothing is captured.
 
 ```python
 from nclutils.sh import run_interactive
@@ -232,7 +234,7 @@ from nclutils.sh import run_interactive
 run_interactive(["ssh", "user@host"])
 ```
 
-`run_interactive` accepts `cwd=`, `env=`, and `sudo=` with the same meaning as `run_command`. It returns the child's integer exit code. When `check=True` (the default), a non-zero exit raises `ShellCommandFailedError` — though `result.stdout` and `result.stderr` will be empty strings because no capture took place.
+`run_interactive` accepts `cwd=`, `env=`, and `sudo=` with the same meaning as `run_command`. It returns the child's integer exit code. When `check=True` (the default), a non-zero exit raises `ShellCommandFailedError`. The `result.stdout` and `result.stderr` fields will be empty strings because no capture took place.
 
 ## Looking up a command
 
@@ -257,7 +259,7 @@ The previous `nclutils.sh` module was a thin wrapper around the third-party `sh`
 | `run_command("git", ["status"])`                              | `run_command(["git", "status"])`                              |
 | `output = run_command(...)` (returned `str`)                  | `result = run_command(...)` then `result.stdout`              |
 | `pushd=Path("/tmp")`                                          | `cwd=Path("/tmp")`                                            |
-| `quiet=True` (captured silently)                              | Default behavior — `stream=False` is the default             |
+| `quiet=True` (captured silently)                              | Default behavior; `stream=False` is the default               |
 | `quiet=False` (streamed to console)                           | `stream=True`                                                 |
 | `err_to_out=True`                                             | **Default behavior change.** The old default `err_to_out=True` folded stderr into the returned string. The new return value gives you `result.stdout` and `result.stderr` separately. If you previously did `output = run_command("foo", ["--bar"])` and your code expected stderr to be in `output`, switch to `result.stdout + result.stderr` after the call (or invoke `sh -c "foo --bar 2>&1"` if you need true interleaving). |
 | `fg=True` (interactive, no capture)                           | `run_interactive([...])`                                      |

--- a/docs/shell_commands.md
+++ b/docs/shell_commands.md
@@ -49,6 +49,8 @@ result = run_command(["rsync", "-av", "src/", "dst/"], stream=True)
 print(f"finished in {result.duration:.1f}s")
 ```
 
+> **Note:** stdout and stderr are drained by separate threads, so within each stream lines stay in order, but the relative interleaving between stdout and stderr is not deterministic. If you need true chronological interleaving, run the command via `sh -c "... 2>&1"` and inspect `result.stdout`.
+
 ## Options
 
 ### `cwd=` — working directory
@@ -257,7 +259,7 @@ The previous `nclutils.sh` module was a thin wrapper around the third-party `sh`
 | `pushd=Path("/tmp")`                                          | `cwd=Path("/tmp")`                                            |
 | `quiet=True` (captured silently)                              | Default behavior — `stream=False` is the default             |
 | `quiet=False` (streamed to console)                           | `stream=True`                                                 |
-| `err_to_out=True`                                             | Removed — `result.stderr` is always available separately      |
+| `err_to_out=True`                                             | **Default behavior change.** The old default `err_to_out=True` folded stderr into the returned string. The new return value gives you `result.stdout` and `result.stderr` separately. If you previously did `output = run_command("foo", ["--bar"])` and your code expected stderr to be in `output`, switch to `result.stdout + result.stderr` after the call (or invoke `sh -c "foo --bar 2>&1"` if you need true interleaving). |
 | `fg=True` (interactive, no capture)                           | `run_interactive([...])`                                      |
 | `e.exit_code`, `e.stdout`, `e.stderr`, `e.full_cmd`           | `e.result.returncode`, `e.result.stdout`, `e.result.stderr`   |
 

--- a/docs/shell_commands.md
+++ b/docs/shell_commands.md
@@ -1,129 +1,273 @@
 # Shell commands
 
-Run external commands with consistent error handling and live output. A small layer over the [sh](https://github.com/amoffat/sh) module. Imported from `nclutils.sh`.
+A thin wrapper over stdlib `subprocess` for running external commands. Imported from `nclutils.sh`. Results come back as a typed `CompletedCommand` dataclass rather than raw strings, and every failure mode maps to a specific exception class. Output goes to `sys.stdout`/`sys.stderr` directly — `nclutils.sh` does not route through `nclutils.pretty_print`'s console.
 
 ```python
+from pathlib import Path
 from nclutils.sh import run_command, which
 
+# Check a tool is present before using it
 if which("git"):
-    run_command("git", ["status", "--short"])
+    result = run_command(["git", "status", "--short"])
+    if result.stdout.strip():
+        print("dirty working tree")
 ```
 
 ## Running commands
 
-`run_command(cmd, args, ...)` runs a command, streams its output to the console as it arrives, and returns the full captured output as a string. ANSI color codes are preserved.
+`run_command(argv, ...)` takes the command and all its arguments as a single list, runs the process, and returns a `CompletedCommand`. By default output is captured silently; pass `stream=True` to tee it to the terminal in real time.
 
 ```python
 from nclutils.sh import run_command
 
-# Print output to the console as it streams
-run_command("ls", ["-la", "/some/path"])
-
-# Capture quietly and inspect after
-output = run_command("git", ["status", "--short"], quiet=True)
-if output.strip():
-    print("dirty working tree")
+result = run_command(["git", "log", "--oneline", "-5"])
+print(result.stdout)
 ```
 
-### Changing directory
+### CompletedCommand fields
 
-Pass `pushd=` to run the command from a different working directory. Empty string (the default) means "use the current directory."
+Every call to `run_command` returns a `CompletedCommand` (a frozen dataclass):
+
+| Field        | Type             | Description                                         |
+| ------------ | ---------------- | --------------------------------------------------- |
+| `argv`       | `tuple[str, ...]` | The full argument list that was executed.          |
+| `returncode` | `int`            | The process exit code.                              |
+| `stdout`     | `str`            | Captured standard output.                          |
+| `stderr`     | `str`            | Captured standard error (always separate).         |
+| `duration`   | `float`          | Wall-clock seconds the process ran.                |
+| `cwd`        | `Path \| None`   | Resolved working directory, or `None` if inherited. |
+| `ok`         | `bool` (property) | `True` when `returncode == 0`.                    |
+
+### Streaming output
+
+Pass `stream=True` to print output to the terminal as it arrives while still capturing it:
+
+```python
+from nclutils.sh import run_command
+
+result = run_command(["rsync", "-av", "src/", "dst/"], stream=True)
+print(f"finished in {result.duration:.1f}s")
+```
+
+## Options
+
+### `cwd=` — working directory
+
+Pass a `Path` or `str` to run the command from a different directory. `None` (the default) inherits the parent process's working directory.
 
 ```python
 from pathlib import Path
 from nclutils.sh import run_command
 
-run_command("pwd", [], pushd=Path("/tmp"))
+result = run_command(["pwd"], cwd=Path("/tmp"))
 ```
 
-If `pushd` cannot be entered (missing, not a directory, or no permission), `run_command` raises `ShellCommandFailedError` with the underlying OS error in the message.
+If `cwd` cannot be entered — missing, not a directory, or no permission — `run_command` raises `ShellCommandFailedError` before the process starts (`result` will be `None` on that exception).
 
-### Allowing non-zero exit codes
+### `env=` — environment variables
 
-Some commands use exit codes as data — `grep` returns `1` when there are no matches, `diff` returns `1` for differences. Pass `okay_codes=` to whitelist additional codes.
+When `env=` is provided it *replaces* the child's entire environment. To extend the current environment, merge it explicitly:
+
+```python
+import os
+from nclutils.sh import run_command
+
+result = run_command(
+    ["printenv", "MY_VAR"],
+    env={**os.environ, "MY_VAR": "hello"},
+)
+```
+
+Passing `env=None` (the default) inherits the parent's environment unchanged.
+
+### `input=` — stdin
+
+Pass a string or bytes to write to the child's stdin:
 
 ```python
 from nclutils.sh import run_command
 
-# 0 (matched) and 1 (no match) are both fine; only 2+ raise
-run_command("grep", ["pattern", "file.txt"], okay_codes=(0, 1))
+result = run_command(["wc", "-w"], input="hello world")
+print(result.stdout.strip())  # "2"
 ```
 
-`okay_codes` defaults to `(0,)`. An empty value falls back to `[0]`.
+For large inputs (>64 KB) where the child also produces output, a deadlock is possible because stdin is fully written before stdout starts draining. Use shell redirection in that case.
 
-### Filtering output
+### `timeout=` — time limit
 
-`exclude_regex=` skips lines that match the given regex. Skipped lines are dropped from both the streamed console output and the returned string.
+Pass a number of seconds. If the process runs longer, it is killed and `ShellCommandTimeoutError` is raised:
+
+```python
+from nclutils.sh import ShellCommandTimeoutError, run_command
+
+try:
+    run_command(["sleep", "10"], timeout=2.0)
+except ShellCommandTimeoutError as e:
+    print(f"killed after {e.timeout}s")
+    print(f"partial stdout: {e.result.stdout!r}")
+```
+
+### `exclude_regex=` — filter lines
+
+Lines matching this regex are dropped from both the streamed output and the captured strings. Useful for suppressing noisy warnings:
 
 ```python
 from nclutils.sh import run_command
 
-run_command("npm", ["install"], exclude_regex=r"^npm warn deprecated")
+run_command(["npm", "install"], stream=True, exclude_regex=r"^npm warn deprecated")
 ```
 
-### Other options
+### `check=False` — skip failure check
 
-- `quiet=True`. Collect output without printing it to the console.
-- `sudo=True`. Run under `sudo`. Requires either an interactive TTY for the password prompt or `NOPASSWD` configured in `sudoers`; will hang or fail in non-interactive contexts (CI, daemons) otherwise.
-- `err_to_out=True` (the default). Fold stderr into the captured stdout. Set to `False` to suppress stderr from both the streamed console output and the returned string.
-- `fg=True`. Run the command in the foreground without capturing output. Use this for interactive commands like `vim` or `less`. The return value is always an empty string.
+By default `run_command` raises `ShellCommandFailedError` on any non-zero exit. Pass `check=False` to suppress this and inspect the return code yourself:
 
-## Errors
+```python
+from nclutils.sh import run_command
 
-Failures from `run_command` come back as one of two exception types.
+result = run_command(["false"], check=False)
+print(result.returncode)  # 1
+```
+
+### `okay_codes=` — acceptable exit codes
+
+Some commands use non-zero exits as data. `grep` returns `1` when no lines match; `diff` returns `1` for non-identical files. Pass `okay_codes=` to treat additional codes as success:
+
+```python
+from nclutils.sh import run_command
+
+# Exit 0 (matched) and 1 (no match) are both fine; only 2+ raises
+result = run_command(
+    ["grep", "pattern", "file.txt"],
+    okay_codes=(0, 1),
+)
+```
+
+### `sudo=True` — run as root
+
+Prepends `["sudo"]` to the argument list. Cached credentials are used; `sudo -k` is never called. This requires an interactive TTY for the password prompt or `NOPASSWD` in sudoers — it will hang or fail in non-interactive contexts such as CI.
+
+```python
+from nclutils.sh import run_command
+
+run_command(["systemctl", "restart", "nginx"], sudo=True)
+```
+
+## Error handling
+
+All errors from `nclutils.sh` inherit from `ShellCommandError`, so a single `except ShellCommandError` catches every failure:
+
+```python
+from nclutils.sh import ShellCommandError, run_command
+
+try:
+    run_command(["git", "push", "origin", "main"])
+except ShellCommandError as e:
+    print(f"command failed: {e}")
+```
+
+The four exception classes and when each is raised:
+
+| Exception                   | When raised                                                      |
+| --------------------------- | ---------------------------------------------------------------- |
+| `ShellCommandNotFoundError` | `argv[0]` is not on PATH.                                        |
+| `ShellCommandFailedError`   | Process exited outside `okay_codes`, or `cwd` can't be entered. |
+| `ShellCommandTimeoutError`  | Process exceeded `timeout=` and was killed.                      |
+| `ShellCommandError`         | Base class; catch this to handle all three above uniformly.      |
 
 ### `ShellCommandNotFoundError`
-
-The command wasn't found in `PATH`.
 
 ```python
 from nclutils.sh import ShellCommandNotFoundError, run_command
 
 try:
-    run_command("not-a-real-command", [])
+    run_command(["not-a-real-command", "--help"])
 except ShellCommandNotFoundError as e:
     print(e)
 ```
 
 ### `ShellCommandFailedError`
 
-The command ran but exited with a status not in `okay_codes`. The exception exposes the relevant context as attributes:
-
-| Attribute    | Meaning                                                                |
-| ------------ | ---------------------------------------------------------------------- |
-| `exit_code`  | The exit status returned by the command.                               |
-| `stdout`     | The stdout output captured by `sh`.                                    |
-| `stderr`     | The stderr output captured by `sh`.                                    |
-| `full_cmd`   | The full command string that was executed.                             |
+The `result` attribute holds a `CompletedCommand` (or `None` if `cwd` couldn't be entered):
 
 ```python
 from nclutils.sh import ShellCommandFailedError, run_command
 
 try:
-    run_command("git", ["push"])
+    run_command(["git", "push", "origin", "main"])
 except ShellCommandFailedError as e:
-    print(f"git push exited {e.exit_code}")
-    print(e.stderr)
+    if e.result is not None:
+        print(f"exit {e.result.returncode}")
+        print(e.result.stderr)
 ```
 
-The exception is also raised when `pushd=` cannot be entered (missing, not a directory, or no permission). In that case the four attributes above are all `None` because no command actually ran; the underlying `OSError` is chained as `__cause__` and its description is included in the message.
+### `ShellCommandTimeoutError`
+
+`result` contains the partial output captured before the process was killed, and `timeout` holds the limit you set:
+
+```python
+from nclutils.sh import ShellCommandTimeoutError, run_command
+
+try:
+    run_command(["sleep", "60"], timeout=5.0)
+except ShellCommandTimeoutError as e:
+    print(f"timed out after {e.timeout}s")
+    print(f"stdout so far: {e.result.stdout!r}")
+```
+
+## Interactive commands
+
+Use `run_interactive` for commands that need a real terminal — editors, pagers, SSH sessions, anything that drives the terminal directly. The child inherits stdin, stdout, and stderr from the parent; nothing is captured.
+
+```python
+from nclutils.sh import run_interactive
+
+exit_code = run_interactive(["vim", "notes.txt"])
+```
+
+```python
+from nclutils.sh import run_interactive
+
+run_interactive(["ssh", "user@host"])
+```
+
+`run_interactive` accepts `cwd=`, `env=`, and `sudo=` with the same meaning as `run_command`. It returns the child's integer exit code. When `check=True` (the default), a non-zero exit raises `ShellCommandFailedError` — though `result.stdout` and `result.stderr` will be empty strings because no capture took place.
 
 ## Looking up a command
 
-`which(cmd)` returns the absolute path of an executable in `PATH`, or `None` if the command isn't found. Use it to gate optional features without try/except.
+`which(cmd)` returns the absolute `Path` to an executable on PATH, or `None` if it's not found. Use it to gate optional functionality without raising:
 
 ```python
 from nclutils.sh import which
 
-if which("docker"):
-    run_command("docker", ["ps"])
+rg = which("rg")
+if rg:
+    print(f"ripgrep is at {rg}")
 else:
-    print("docker not installed; skipping container checks")
+    print("ripgrep not installed; falling back to grep")
 ```
+
+## Migrating from the old API
+
+The previous `nclutils.sh` module was a thin wrapper around the third-party `sh` package. The new implementation uses stdlib `subprocess` directly.
+
+| Old usage                                                     | New usage                                                     |
+| ------------------------------------------------------------- | ------------------------------------------------------------- |
+| `run_command("git", ["status"])`                              | `run_command(["git", "status"])`                              |
+| `output = run_command(...)` (returned `str`)                  | `result = run_command(...)` then `result.stdout`              |
+| `pushd=Path("/tmp")`                                          | `cwd=Path("/tmp")`                                            |
+| `quiet=True` (captured silently)                              | Default behavior — `stream=False` is the default             |
+| `quiet=False` (streamed to console)                           | `stream=True`                                                 |
+| `err_to_out=True`                                             | Removed — `result.stderr` is always available separately      |
+| `fg=True` (interactive, no capture)                           | `run_interactive([...])`                                      |
+| `e.exit_code`, `e.stdout`, `e.stderr`, `e.full_cmd`           | `e.result.returncode`, `e.result.stdout`, `e.result.stderr`   |
 
 ## API reference
 
-- `run_command(cmd, args, pushd="", okay_codes=(0,), exclude_regex=None, *, quiet=False, sudo=False, err_to_out=True, fg=False) -> str`. Run a command and return its captured output.
-- `which(cmd) -> str | None`. Resolve a command name to an absolute path, or `None`.
-- `ShellCommandFailedError`. Raised on non-zero exit. Exposes `exit_code`, `stdout`, `stderr`, `full_cmd`.
-- `ShellCommandNotFoundError`. Raised when the command isn't in `PATH`.
+- `run_command(argv, *, cwd=None, env=None, input=None, timeout=None, exclude_regex=None, stream=False, check=True, okay_codes=(0,), sudo=False) -> CompletedCommand`. Run a non-interactive command and return captured output.
+- `run_interactive(argv, *, cwd=None, env=None, sudo=False, check=True) -> int`. Run a command with a real terminal. Returns the exit code.
+- `which(cmd) -> Path | None`. Resolve an executable name to its absolute path, or `None` if not found.
+- `CompletedCommand`. Frozen dataclass returned by `run_command`. Fields: `argv`, `returncode`, `stdout`, `stderr`, `duration`, `cwd`. Property: `ok`.
+- `ShellCommandError`. Base exception for all `nclutils.sh` failures.
+- `ShellCommandNotFoundError`. Raised when `argv[0]` is not on PATH.
+- `ShellCommandFailedError`. Raised on non-zero exit or unreachable `cwd`. Carries `result: CompletedCommand | None`.
+- `ShellCommandTimeoutError`. Raised when `timeout=` is exceeded. Carries `result: CompletedCommand` and `timeout: float`.

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -117,7 +117,7 @@ If the text is already at or beyond the target length, the original string is re
 
 ### `random_string`
 
-Generate a random ASCII letter string of a given length. Uses `random.choice`, so it's not cryptographically secure — for that, use `nclutils.utils.new_uid` instead.
+Generate a random ASCII letter string of a given length. Uses `random.choice`, so it's not cryptographically secure; for that, use `nclutils.utils.new_uid` instead.
 
 ```python
 from nclutils.strings import random_string

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -74,7 +74,8 @@ unique_id("id_")   # "id_2"
 unique_id()        # "3"
 ```
 
-> **Note:** `unique_id` is sequential, not random. It's useful for short-lived labels (test fixtures, in-memory IDs) but isn't safe across processes or restarts.
+> [!NOTE]
+> `unique_id` is sequential, not random. It's useful for short-lived labels (test fixtures, in-memory IDs) but isn't safe across processes or restarts.
 
 ## Python version checks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
     ]
-    dependencies = ["questionary>=2.1.1", "rich>=15.0.0", "sh>=2.2.2"]
+    dependencies = ["questionary>=2.1.1", "rich>=15.0.0"]
     description = "Collection of convenience functions used in Python packages and scripts."
     license = "MIT"
     license-files = ["LICENSE"]

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -458,10 +458,7 @@ def find_user_home_dir(username: str | None = None) -> Path | None:
     if platform.system() == "Linux":
         try:
             return Path(
-                run_command("getent", ["passwd", username], quiet=True)
-                .strip()
-                .split(":")[5]
-                .strip()
+                run_command(["getent", "passwd", username]).stdout.strip().split(":")[5].strip()
             )
         except ShellCommandFailedError:
             return None
@@ -469,10 +466,8 @@ def find_user_home_dir(username: str | None = None) -> Path | None:
     if platform.system() == "Darwin":
         try:
             return Path(
-                run_command(
-                    "dscl", [".", "-read", f"/Users/{username}", "NFSHomeDirectory"], quiet=True
-                )
-                .strip()
+                run_command(["dscl", ".", "-read", f"/Users/{username}", "NFSHomeDirectory"])
+                .stdout.strip()
                 .split(":")[1]
                 .strip()
             )

--- a/src/nclutils/sh/__init__.py
+++ b/src/nclutils/sh/__init__.py
@@ -1,11 +1,20 @@
 """Run shell commands."""
 
-from .errors import ShellCommandFailedError, ShellCommandNotFoundError
+from .errors import (
+    CompletedCommand,
+    ShellCommandError,
+    ShellCommandFailedError,
+    ShellCommandNotFoundError,
+    ShellCommandTimeoutError,
+)
 from .shell_command import run_command, which
 
 __all__ = [
+    "CompletedCommand",
+    "ShellCommandError",
     "ShellCommandFailedError",
     "ShellCommandNotFoundError",
+    "ShellCommandTimeoutError",
     "run_command",
     "which",
 ]

--- a/src/nclutils/sh/__init__.py
+++ b/src/nclutils/sh/__init__.py
@@ -7,7 +7,7 @@ from .errors import (
     ShellCommandNotFoundError,
     ShellCommandTimeoutError,
 )
-from .shell_command import run_command, which
+from .shell_command import run_command, run_interactive, which
 
 __all__ = [
     "CompletedCommand",
@@ -16,5 +16,6 @@ __all__ = [
     "ShellCommandNotFoundError",
     "ShellCommandTimeoutError",
     "run_command",
+    "run_interactive",
     "which",
 ]

--- a/src/nclutils/sh/_streaming.py
+++ b/src/nclutils/sh/_streaming.py
@@ -1,0 +1,41 @@
+"""Line-buffered pipe reader used by run_command's streaming path."""
+
+from __future__ import annotations
+
+import re  # noqa: TC003 -- runtime import to avoid future footgun if re is used in body
+from typing import IO
+
+
+def pump_pipe(
+    pipe: IO[bytes],
+    buffer: list[str],
+    sink: IO[str] | None,
+    exclude_pattern: re.Pattern[str] | None,
+) -> None:
+    """Read ``pipe`` line-by-line, decode, filter, and forward each line.
+
+    Designed to run in a worker thread; the caller owns ``buffer`` and must
+    not read it until the worker has joined.
+
+    The sink is flushed after every line so block-buffered redirection
+    (e.g., ``> file.log``) still produces real-time output.
+
+    Args:
+        pipe: A binary-mode readable pipe (stdout or stderr from a subprocess).
+        buffer: Accumulator list; each decoded line is appended in order.
+        sink: Optional text-mode stream to mirror output to (e.g. sys.stdout).
+            Pass ``None`` to suppress forwarding.
+        exclude_pattern: Pre-compiled regex; lines that match are dropped from
+            both ``buffer`` and ``sink``.  Pass ``None`` to keep every line.
+    """
+    try:
+        for raw in pipe:
+            line = raw.decode("utf-8")
+            if exclude_pattern is not None and exclude_pattern.search(line):
+                continue
+            buffer.append(line)
+            if sink is not None:
+                sink.write(line)
+                sink.flush()
+    finally:
+        pipe.close()

--- a/src/nclutils/sh/errors.py
+++ b/src/nclutils/sh/errors.py
@@ -1,45 +1,98 @@
-"""Custom errors for script utilities."""
+"""Errors raised by nclutils.sh."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
 
 
-def _decode(output: bytes | str | None) -> str | None:
-    """Decode subprocess output (bytes/str/None) to a stripped string or None."""
-    if output is None:
-        return None
-    if isinstance(output, bytes):
-        try:
-            return output.decode("utf-8").strip()
-        except UnicodeDecodeError:  # pragma: no cover
-            return str(output).strip()
-    return str(output).strip()
+@dataclass(frozen=True, slots=True)
+class CompletedCommand:
+    """The full record of a finished subprocess invocation.
+
+    Returned from :func:`run_command` on success and exposed as ``.result`` on
+    :class:`ShellCommandFailedError` / :class:`ShellCommandTimeoutError`.
+    """
+
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+    duration: float
+    cwd: Path | None
+
+    @property
+    def ok(self) -> bool:
+        """Return True when the command exited with status 0."""
+        return self.returncode == 0
 
 
-class ShellCommandFailedError(Exception):
-    """Raised when a shell command fails."""
+class ShellCommandError(Exception):
+    """Base class for every error raised by nclutils.sh."""
 
-    def __init__(self, msg: str | None = None, *, e: Exception | None = None) -> None:
-        self.exit_code: int | None = getattr(e, "exit_code", None)
-        self.stderr: str | None = _decode(getattr(e, "stderr", None))
-        self.stdout: str | None = _decode(getattr(e, "stdout", None))
-        self.full_cmd: str | None = _decode(getattr(e, "full_cmd", None))
 
-        parts = [msg or "Shell command failed."]
+class ShellCommandNotFoundError(ShellCommandError):
+    """Raised when argv[0] cannot be located on PATH."""
+
+    def __init__(
+        self,
+        argv: Sequence[str],
+        *,
+        msg: str | None = None,
+        e: Exception | None = None,
+    ) -> None:
+        self.argv: tuple[str, ...] = tuple(argv)
+        executable = self.argv[0] if self.argv else "<empty>"
+        parts = [msg or f"Command not found on PATH: {executable}"]
         if e is not None:
             parts.append(f"Raised from: {e.__class__.__name__}: {e}")
-            if self.stderr:
-                parts.append(f"Stderr: {self.stderr}")
-            if self.stdout:
-                parts.append(f"Stdout: {self.stdout}")
-            if self.full_cmd:
-                parts.append(f"Full command: {self.full_cmd}")
-
         super().__init__("\n".join(parts))
 
 
-class ShellCommandNotFoundError(Exception):
-    """Raised when a shell command is not found."""
+class ShellCommandFailedError(ShellCommandError):
+    """Raised when a command ran but exited outside the configured okay codes.
 
-    def __init__(self, msg: str | None = None, *, e: Exception | None = None) -> None:
-        parts = [msg or "Shell command not found."]
-        if e is not None:
-            parts.append(f"Raised from: {e.__class__.__name__}:\n{e}")
+    Also raised when ``cwd`` cannot be entered (in which case ``result`` is None
+    because no command actually ran; the underlying OSError is chained as
+    ``__cause__``).
+    """
+
+    def __init__(
+        self,
+        *,
+        result: CompletedCommand | None = None,
+        msg: str | None = None,
+    ) -> None:
+        self.result = result
+        if msg is not None:
+            super().__init__(msg)
+            return
+
+        # Build a message from the result.
+        argv_str = " ".join(result.argv) if result is not None else "<unknown>"
+        rc = result.returncode if result is not None else "<unknown>"
+        parts = [f"Shell command failed: {argv_str} (exit code {rc})"]
+        if result is not None and result.stderr:
+            parts.append(f"Stderr: {result.stderr.rstrip()}")
+        if result is not None and result.stdout:
+            parts.append(f"Stdout: {result.stdout.rstrip()}")
         super().__init__("\n".join(parts))
+
+
+class ShellCommandTimeoutError(ShellCommandError):
+    """Raised when a command exceeded its ``timeout=`` and was killed."""
+
+    def __init__(
+        self,
+        *,
+        result: CompletedCommand,
+        timeout: float,
+    ) -> None:
+        self.result = result
+        self.timeout = timeout
+        argv_str = " ".join(result.argv)
+        super().__init__(f"Shell command timed out after {timeout}s: {argv_str}")

--- a/src/nclutils/sh/errors.py
+++ b/src/nclutils/sh/errors.py
@@ -75,14 +75,14 @@ class ShellCommandFailedError(ShellCommandError):
         if msg is not None:
             super().__init__(msg)
             return
+        if result is None:
+            super().__init__("Shell command failed (no result captured)")
+            return
 
-        # Build a message from the result.
-        argv_str = " ".join(result.argv) if result is not None else "<unknown>"
-        rc = result.returncode if result is not None else "<unknown>"
-        parts = [f"Shell command failed: {argv_str} (exit code {rc})"]
-        if result is not None and result.stderr:
+        parts = [f"Shell command failed: {' '.join(result.argv)} (exit code {result.returncode})"]
+        if result.stderr:
             parts.append(f"Stderr: {result.stderr.rstrip()}")
-        if result is not None and result.stdout:
+        if result.stdout:
             parts.append(f"Stdout: {result.stdout.rstrip()}")
         super().__init__("\n".join(parts))
 

--- a/src/nclutils/sh/errors.py
+++ b/src/nclutils/sh/errors.py
@@ -40,8 +40,8 @@ class ShellCommandNotFoundError(ShellCommandError):
 
     def __init__(
         self,
-        argv: Sequence[str],
         *,
+        argv: Sequence[str],
         msg: str | None = None,
         e: Exception | None = None,
     ) -> None:
@@ -56,9 +56,13 @@ class ShellCommandNotFoundError(ShellCommandError):
 class ShellCommandFailedError(ShellCommandError):
     """Raised when a command ran but exited outside the configured okay codes.
 
-    Also raised when ``cwd`` cannot be entered (in which case ``result`` is None
+    Also raised when ``cwd`` cannot be entered, in which case ``result`` is None
     because no command actually ran; the underlying OSError is chained as
-    ``__cause__``).
+    ``__cause__``.
+
+    When both ``result`` and ``msg`` are provided, ``msg`` is used verbatim as
+    the exception message and ``result`` remains reachable via ``self.result``.
+    When only ``result`` is provided, the message is auto-built from the result.
     """
 
     def __init__(

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -1,6 +1,7 @@
 """Run and work with shell commands."""
 
 import re
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -21,29 +22,20 @@ def _decode_sh(value: bytes | str | None) -> str:
     return str(value)
 
 
-def which(cmd: str) -> str | None:
-    """Find the absolute path of a command in the system PATH.
+def which(cmd: str) -> Path | None:
+    """Return the absolute Path to ``cmd`` on PATH, or None if it is missing.
 
-    Search through the system PATH environment variable to locate the executable file for the given command name. Use this function to verify command availability before execution or to find the full path to a command.
+    Use this to gate optional features without raising. Wraps
+    :func:`shutil.which`; returns the same answer the shell would pick.
 
     Args:
-        cmd (str): The command name to search for in PATH
+        cmd: The executable name to look up.
 
     Returns:
-        str | None: The absolute path to the command if found, None if the command doesn't exist
-
+        The resolved absolute Path, or None if ``cmd`` is not on PATH.
     """
-    try:
-        result = sh.which(cmd)
-    except (sh.CommandNotFound, sh.ErrorReturnCode):
-        # `sh.which` shells out to /usr/bin/which, which exits 1 when the command is
-        # missing. CommandNotFound covers the case where /usr/bin/which itself is gone.
-        return None
-
-    if result is None:
-        return None
-
-    return str(result).strip()
+    found = shutil.which(cmd)
+    return Path(found) if found is not None else None
 
 
 def run_command(  # noqa: C901, PLR0913

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -106,9 +106,16 @@ def run_command(  # noqa: C901, PLR0913
                 command(*args, **cmd_kwargs)
             return "".join(output_lines)
         except sh.CommandNotFound as e:
-            raise ShellCommandNotFoundError(e=e) from e
+            raise ShellCommandNotFoundError(argv=(cmd,), e=e) from e
         except sh.ErrorReturnCode as e:
-            raise ShellCommandFailedError(e=e) from e
+            stderr = e.stderr.decode("utf-8", errors="replace").strip() if e.stderr else ""
+            stdout = e.stdout.decode("utf-8", errors="replace").strip() if e.stdout else ""
+            full_cmd = str(e.full_cmd) if hasattr(e, "full_cmd") else cmd
+            raise ShellCommandFailedError(
+                msg=f"Shell command failed.\nRaised from: {e.__class__.__name__}: {e}\nFull command: {full_cmd}"
+                + (f"\nStderr: {stderr}" if stderr else "")
+                + (f"\nStdout: {stdout}" if stdout else ""),
+            ) from e
 
     if pushd:
         if not isinstance(pushd, Path):
@@ -123,6 +130,6 @@ def run_command(  # noqa: C901, PLR0913
             # as ShellCommandFailedError so callers don't get raw OSError.
             detail = e.strerror or str(e)
             msg = f"Cannot enter directory {pushd}: {detail}"
-            raise ShellCommandFailedError(msg, e=e) from e
+            raise ShellCommandFailedError(msg=msg) from e
 
     return _execute()

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -215,3 +215,66 @@ def run_command(  # noqa: C901, PLR0912, PLR0913, PLR0915
         raise ShellCommandFailedError(result=result)
 
     return result
+
+
+def run_interactive(
+    argv: Sequence[str],
+    *,
+    cwd: Path | str | None = None,
+    env: Mapping[str, str] | None = None,
+    sudo: bool = False,
+    check: bool = True,
+) -> int:
+    """Run a command that needs a real terminal (vim, less, ssh).
+
+    Inherits the parent's stdin/stdout/stderr — no capture, no pipes, no
+    streaming layer. Use :func:`run_command` for non-interactive commands
+    where you want the captured output.
+
+    Args:
+        argv: Full command including executable.
+        cwd: Working directory; None inherits parent.
+        env: If provided, replaces the child env.
+        sudo: When True, prepends ``["sudo"]`` to argv.
+        check: When True (default), a non-zero exit raises FailedError.
+
+    Returns:
+        The child's exit code.
+    """
+    final_argv: list[str] = list(argv)
+    if sudo:
+        final_argv = ["sudo", *final_argv]
+    final_argv_tuple = tuple(final_argv)
+
+    resolved_cwd = _resolve_cwd(cwd)
+
+    started = time.monotonic()
+    try:
+        proc = subprocess.Popen(  # noqa: S603 -- argv is a list, never shelled
+            final_argv,
+            cwd=resolved_cwd,
+            env=dict(env) if env is not None else None,
+        )
+    except FileNotFoundError as e:
+        raise ShellCommandNotFoundError(argv=final_argv_tuple, e=e) from e
+    except OSError as e:
+        raise ShellCommandFailedError(
+            msg=f"Failed to spawn {final_argv[0]}: {e}",
+            result=None,
+        ) from e
+
+    rc = proc.wait()
+    duration = time.monotonic() - started
+
+    if check and rc != 0:
+        result = CompletedCommand(
+            argv=final_argv_tuple,
+            returncode=rc,
+            stdout="",
+            stderr="",
+            duration=duration,
+            cwd=resolved_cwd,
+        )
+        raise ShellCommandFailedError(result=result)
+
+    return rc

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -144,39 +144,41 @@ def run_command(  # noqa: C901, PLR0912, PLR0913, PLR0915
     sout_sink = sys.stdout if stream else None
     serr_sink = sys.stderr if stream else None
 
-    # proc.stdout and proc.stderr are always set when PIPE is passed to Popen
-    if proc.stdout is None or proc.stderr is None:  # pragma: no cover
+    # proc.stdout and proc.stderr are always set when PIPE is passed to Popen.
+    # Capture into locals so mypy can narrow them inside the drain closures.
+    out_pipe = proc.stdout
+    err_pipe = proc.stderr
+    if out_pipe is None or err_pipe is None:  # pragma: no cover
         _msg = "Popen did not open stdout/stderr pipes as expected"
         raise RuntimeError(_msg)
 
-    pump_errors: dict[str, BaseException | None] = {"out": None, "err": None}
+    out_exc: list[BaseException | None] = [None]
+    err_exc: list[BaseException | None] = [None]
 
-    def _run_pump(slot: str, **kwargs: object) -> None:
+    def _drain_stdout() -> None:
         try:
-            pump_pipe(**kwargs)  # type: ignore[arg-type]
+            pump_pipe(
+                pipe=out_pipe,
+                buffer=stdout_lines,
+                sink=sout_sink,
+                exclude_pattern=exclude_pattern,
+            )
         except BaseException as e:  # noqa: BLE001 -- capture and re-raise from caller
-            pump_errors[slot] = e
+            out_exc[0] = e
 
-    t_out = threading.Thread(
-        target=_run_pump,
-        kwargs={
-            "slot": "out",
-            "pipe": proc.stdout,
-            "buffer": stdout_lines,
-            "sink": sout_sink,
-            "exclude_pattern": exclude_pattern,
-        },
-    )
-    t_err = threading.Thread(
-        target=_run_pump,
-        kwargs={
-            "slot": "err",
-            "pipe": proc.stderr,
-            "buffer": stderr_lines,
-            "sink": serr_sink,
-            "exclude_pattern": exclude_pattern,
-        },
-    )
+    def _drain_stderr() -> None:
+        try:
+            pump_pipe(
+                pipe=err_pipe,
+                buffer=stderr_lines,
+                sink=serr_sink,
+                exclude_pattern=exclude_pattern,
+            )
+        except BaseException as e:  # noqa: BLE001 -- capture and re-raise from caller
+            err_exc[0] = e
+
+    t_out = threading.Thread(target=_drain_stdout)
+    t_err = threading.Thread(target=_drain_stderr)
     t_out.start()
     t_err.start()
 
@@ -193,9 +195,10 @@ def run_command(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     # Surface any pump-thread exception (e.g., UnicodeDecodeError) before evaluating
     # the timeout/check branches so a decode error isn't masked by a normal exit.
-    for err in (pump_errors["out"], pump_errors["err"]):
-        if err is not None:
-            raise err
+    if out_exc[0] is not None:
+        raise out_exc[0]
+    if err_exc[0] is not None:
+        raise err_exc[0]
 
     duration = time.monotonic() - started
     result = CompletedCommand(

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -1,25 +1,26 @@
-"""Run and work with shell commands."""
+"""Run shell commands using stdlib subprocess."""
+
+from __future__ import annotations
 
 import re
 import shutil
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
-import sh
-from rich.text import Text
+from ._streaming import pump_pipe
+from .errors import (
+    CompletedCommand,
+    ShellCommandFailedError,
+    ShellCommandNotFoundError,
+    ShellCommandTimeoutError,
+)
 
-from nclutils.pretty_print import console as get_console
-
-from .errors import CompletedCommand, ShellCommandFailedError, ShellCommandNotFoundError
-
-
-def _decode_sh(value: bytes | str | None) -> str:
-    """Decode sh's stdout/stderr bytes to str, tolerating encoding errors."""
-    if value is None:
-        return ""
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    return str(value)
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 
 def which(cmd: str) -> Path | None:
@@ -38,102 +39,150 @@ def which(cmd: str) -> Path | None:
     return Path(found) if found is not None else None
 
 
-def run_command(  # noqa: C901, PLR0913
-    cmd: str,
-    args: list[str],
-    pushd: str | Path = "",
-    okay_codes: tuple[int, ...] = (0,),
-    exclude_regex: str | None = None,
-    *,
-    quiet: bool = False,
-    sudo: bool = False,
-    err_to_out: bool = True,
-    fg: bool = False,
-) -> str:
-    """Execute a shell command and capture its output with ANSI color support.
+def _resolve_cwd(cwd: Path | str | None) -> Path | None:
+    """Resolve ``cwd`` to an absolute Path or return None for the inherited cwd.
 
-    Run a shell command with the specified arguments while preserving ANSI color codes and terminal formatting. Stream command output to the console in real-time unless quiet mode is enabled. Change to a different working directory before execution if pushd is specified.
+    Raises ShellCommandFailedError(result=None) if the directory cannot be entered.
+    """
+    if cwd is None:
+        return None
+    resolved = Path(cwd).expanduser().resolve()
+    if not resolved.is_dir():
+        raise ShellCommandFailedError(
+            msg=f"Cannot enter directory {resolved}: not a directory",
+            result=None,
+        )
+    return resolved
+
+
+def run_command(  # noqa: PLR0913, PLR0915
+    argv: Sequence[str],
+    *,
+    cwd: Path | str | None = None,
+    env: Mapping[str, str] | None = None,
+    input: str | bytes | None = None,  # noqa: A002 -- mirrors subprocess.run
+    timeout: float | None = None,
+    exclude_regex: str | None = None,
+    stream: bool = False,
+    check: bool = True,
+    okay_codes: tuple[int, ...] = (0,),
+    sudo: bool = False,
+) -> CompletedCommand:
+    """Run a shell command and return a structured CompletedCommand.
+
+    Use this for non-interactive commands. For commands that need a real terminal
+    (vim, less, ssh), use :func:`run_interactive` instead (added in a later task).
 
     Args:
-        cmd (str): The command name to execute
-        args (list[str]): Command line arguments to pass to the command
-        pushd (str | Path): Directory to change to before running the command. Empty string means current directory. Defaults to "".
-        okay_codes (tuple[int, ...]): Exit codes that are considered successful. Defaults to (0,).
-        exclude_regex (str | None): Regex to exclude lines from the output. Defaults to None.
-        quiet (bool): Whether to suppress real-time output to console. Defaults to False.
-        sudo (bool): Whether to run the command with sudo. Requires either an interactive TTY for the password prompt or NOPASSWD configured in sudoers; will hang or fail in non-interactive contexts otherwise. Defaults to False.
-        err_to_out (bool): Whether to fold stderr into the captured stdout. When False, stderr is suppressed from both the streamed console output and the returned string. Defaults to True.
-        fg (bool): Whether to run the command in foreground without capturing output. Returns an empty string when True; use this for interactive commands like vim or less. Defaults to False.
+        argv: Full command including executable. Passed verbatim to subprocess.
+        cwd: Working directory; None inherits the parent's cwd.
+        env: If provided, replaces the child env. Caller extends via ``{**os.environ, ...}``.
+        input: Text or bytes written to the child's stdin and then closed.
+        timeout: Seconds before the child is terminated and TimeoutError raised.
+        exclude_regex: Lines matching this regex are dropped from both the streamed
+            output and the captured strings.
+        stream: When True, also tees stdout/stderr to sys.stdout/sys.stderr live.
+        check: When True (default), a returncode not in ``okay_codes`` raises FailedError.
+        okay_codes: Returncodes treated as success when ``check=True``.
+        sudo: When True, prepends ``["sudo"]`` to argv.
 
     Returns:
-        str: The complete command output as a string with ANSI color codes preserved, or an empty string when fg=True
-
-    Raises:
-        ShellCommandNotFoundError: When the command is not found in PATH
-        ShellCommandFailedError: When the command exits with a non-zero status code
+        CompletedCommand with stdout, stderr, returncode, argv, duration, cwd.
     """
-    output_lines: list[str] = []
-    # Compile once instead of per-line — significant for high-volume output.
+    final_argv: list[str] = list(argv)
+    if sudo:
+        final_argv = ["sudo", *final_argv]
+    final_argv_tuple = tuple(final_argv)
+
+    resolved_cwd = _resolve_cwd(cwd)
     exclude_pattern = re.compile(exclude_regex) if exclude_regex else None
-    # Resolve the shared pretty_print console once per call so set_default()
-    # swaps in the host application still take effect between invocations.
-    console = get_console()
 
-    def _on_line(line: str) -> None:
-        if exclude_pattern is not None and exclude_pattern.search(line):
-            return
-        output_lines.append(line)
-        if not quiet:
-            console.print(Text.from_ansi(line))
+    # input: bytes go through unchanged; str is encoded utf-8.
+    input_bytes: bytes | None
+    if input is None:
+        input_bytes = None
+    elif isinstance(input, bytes):
+        input_bytes = input
+    else:
+        input_bytes = input.encode("utf-8")
 
-    def _execute() -> str:
-        ok_code = list(okay_codes) or [0]
-        if fg:
-            cmd_kwargs: dict[str, Any] = {"_fg": True, "_ok_code": ok_code}
-        else:
-            cmd_kwargs = {"_out": _on_line, "_ok_code": ok_code, "_tee": "err"}
-            if err_to_out:
-                cmd_kwargs["_err"] = _on_line
+    stdin = subprocess.PIPE if input_bytes is not None else subprocess.DEVNULL
 
+    started = time.monotonic()
+    try:
+        proc = subprocess.Popen(  # noqa: S603 -- argv is a list, never shelled
+            final_argv,
+            cwd=resolved_cwd,
+            env=dict(env) if env is not None else None,
+            stdin=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as e:
+        raise ShellCommandNotFoundError(argv=final_argv_tuple, e=e) from e
+
+    if input_bytes is not None and proc.stdin is not None:
         try:
-            command = sh.Command(cmd)
-            if sudo:
-                # Do NOT pass `k=True` — that would invalidate cached sudo credentials
-                # before each invocation, forcing a password prompt every call and
-                # hanging in non-interactive contexts (CI, daemons).
-                with sh.contrib.sudo(_with=True):
-                    command(*args, **cmd_kwargs)
-            else:
-                command(*args, **cmd_kwargs)
-            return "".join(output_lines)
-        except sh.CommandNotFound as e:
-            raise ShellCommandNotFoundError(argv=(cmd,), e=e) from e
-        except sh.ErrorReturnCode as e:
-            stdout_text = _decode_sh(e.stdout)
-            stderr_text = _decode_sh(e.stderr)
-            completed = CompletedCommand(
-                argv=(cmd, *args),
-                returncode=e.exit_code,
-                stdout=stdout_text,
-                stderr=stderr_text,
-                duration=0.0,
-                cwd=None,
-            )
-            raise ShellCommandFailedError(result=completed) from e
+            proc.stdin.write(input_bytes)
+        finally:
+            proc.stdin.close()
 
-    if pushd:
-        if not isinstance(pushd, Path):
-            pushd = Path(pushd)
-        pushd = pushd.expanduser().absolute()
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+    sout_sink = sys.stdout if stream else None
+    serr_sink = sys.stderr if stream else None
 
-        try:
-            with sh.pushd(pushd):
-                return _execute()
-        except OSError as e:
-            # Surface chdir-time failures (missing dir, not-a-directory, permission)
-            # as ShellCommandFailedError so callers don't get raw OSError.
-            detail = e.strerror or str(e)
-            msg = f"Cannot enter directory {pushd}: {detail}"
-            raise ShellCommandFailedError(msg=msg) from e
+    # proc.stdout and proc.stderr are always set when PIPE is passed to Popen
+    if proc.stdout is None or proc.stderr is None:  # pragma: no cover
+        _msg = "Popen did not open stdout/stderr pipes as expected"
+        raise RuntimeError(_msg)
+    t_out = threading.Thread(
+        target=pump_pipe,
+        kwargs={
+            "pipe": proc.stdout,
+            "buffer": stdout_lines,
+            "sink": sout_sink,
+            "exclude_pattern": exclude_pattern,
+        },
+    )
+    t_err = threading.Thread(
+        target=pump_pipe,
+        kwargs={
+            "pipe": proc.stderr,
+            "buffer": stderr_lines,
+            "sink": serr_sink,
+            "exclude_pattern": exclude_pattern,
+        },
+    )
+    t_out.start()
+    t_err.start()
 
-    return _execute()
+    timed_out = False
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        proc.kill()
+        proc.wait()
+    finally:
+        t_out.join()
+        t_err.join()
+
+    duration = time.monotonic() - started
+    result = CompletedCommand(
+        argv=final_argv_tuple,
+        returncode=proc.returncode,
+        stdout="".join(stdout_lines),
+        stderr="".join(stderr_lines),
+        duration=duration,
+        cwd=resolved_cwd,
+    )
+
+    if timed_out:
+        # timeout is non-None when timed_out is True (TimeoutExpired only fires with timeout)
+        raise ShellCommandTimeoutError(result=result, timeout=timeout)  # type: ignore[arg-type]
+
+    if check and proc.returncode not in okay_codes:
+        raise ShellCommandFailedError(result=result)
+
+    return result

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -55,7 +55,7 @@ def _resolve_cwd(cwd: Path | str | None) -> Path | None:
     return resolved
 
 
-def run_command(  # noqa: PLR0913, PLR0915
+def run_command(  # noqa: C901, PLR0912, PLR0913, PLR0915
     argv: Sequence[str],
     *,
     cwd: Path | str | None = None,
@@ -78,6 +78,9 @@ def run_command(  # noqa: PLR0913, PLR0915
         cwd: Working directory; None inherits the parent's cwd.
         env: If provided, replaces the child env. Caller extends via ``{**os.environ, ...}``.
         input: Text or bytes written to the child's stdin and then closed.
+            For large inputs (>64KB) where the child also produces output,
+            deadlock is possible because stdout drainage starts after stdin
+            is fully written; pipe via shell redirection in that case.
         timeout: Seconds before the child is terminated and TimeoutError raised.
         exclude_regex: Lines matching this regex are dropped from both the streamed
             output and the captured strings.
@@ -120,10 +123,19 @@ def run_command(  # noqa: PLR0913, PLR0915
         )
     except FileNotFoundError as e:
         raise ShellCommandNotFoundError(argv=final_argv_tuple, e=e) from e
+    except OSError as e:
+        raise ShellCommandFailedError(
+            msg=f"Failed to spawn {final_argv[0]}: {e}",
+            result=None,
+        ) from e
 
     if input_bytes is not None and proc.stdin is not None:
         try:
             proc.stdin.write(input_bytes)
+        except BrokenPipeError:
+            # Child exited before consuming stdin. Let the normal returncode path
+            # surface the failure via ShellCommandFailedError (or check=False).
+            pass
         finally:
             proc.stdin.close()
 
@@ -136,9 +148,19 @@ def run_command(  # noqa: PLR0913, PLR0915
     if proc.stdout is None or proc.stderr is None:  # pragma: no cover
         _msg = "Popen did not open stdout/stderr pipes as expected"
         raise RuntimeError(_msg)
+
+    pump_errors: dict[str, BaseException | None] = {"out": None, "err": None}
+
+    def _run_pump(slot: str, **kwargs: object) -> None:
+        try:
+            pump_pipe(**kwargs)  # type: ignore[arg-type]
+        except BaseException as e:  # noqa: BLE001 -- capture and re-raise from caller
+            pump_errors[slot] = e
+
     t_out = threading.Thread(
-        target=pump_pipe,
+        target=_run_pump,
         kwargs={
+            "slot": "out",
             "pipe": proc.stdout,
             "buffer": stdout_lines,
             "sink": sout_sink,
@@ -146,8 +168,9 @@ def run_command(  # noqa: PLR0913, PLR0915
         },
     )
     t_err = threading.Thread(
-        target=pump_pipe,
+        target=_run_pump,
         kwargs={
+            "slot": "err",
             "pipe": proc.stderr,
             "buffer": stderr_lines,
             "sink": serr_sink,
@@ -167,6 +190,12 @@ def run_command(  # noqa: PLR0913, PLR0915
     finally:
         t_out.join()
         t_err.join()
+
+    # Surface any pump-thread exception (e.g., UnicodeDecodeError) before evaluating
+    # the timeout/check branches so a decode error isn't masked by a normal exit.
+    for err in (pump_errors["out"], pump_errors["err"]):
+        if err is not None:
+            raise err
 
     duration = time.monotonic() - started
     result = CompletedCommand(

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -9,7 +9,16 @@ from rich.text import Text
 
 from nclutils.pretty_print import console as get_console
 
-from .errors import ShellCommandFailedError, ShellCommandNotFoundError
+from .errors import CompletedCommand, ShellCommandFailedError, ShellCommandNotFoundError
+
+
+def _decode_sh(value: bytes | str | None) -> str:
+    """Decode sh's stdout/stderr bytes to str, tolerating encoding errors."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
 
 
 def which(cmd: str) -> str | None:
@@ -108,14 +117,17 @@ def run_command(  # noqa: C901, PLR0913
         except sh.CommandNotFound as e:
             raise ShellCommandNotFoundError(argv=(cmd,), e=e) from e
         except sh.ErrorReturnCode as e:
-            stderr = e.stderr.decode("utf-8", errors="replace").strip() if e.stderr else ""
-            stdout = e.stdout.decode("utf-8", errors="replace").strip() if e.stdout else ""
-            full_cmd = str(e.full_cmd) if hasattr(e, "full_cmd") else cmd
-            raise ShellCommandFailedError(
-                msg=f"Shell command failed.\nRaised from: {e.__class__.__name__}: {e}\nFull command: {full_cmd}"
-                + (f"\nStderr: {stderr}" if stderr else "")
-                + (f"\nStdout: {stdout}" if stdout else ""),
-            ) from e
+            stdout_text = _decode_sh(e.stdout)
+            stderr_text = _decode_sh(e.stderr)
+            completed = CompletedCommand(
+                argv=(cmd, *args),
+                returncode=e.exit_code,
+                stdout=stdout_text,
+                stderr=stderr_text,
+                duration=0.0,
+                cwd=None,
+            )
+            raise ShellCommandFailedError(result=completed) from e
 
     if pushd:
         if not isinstance(pushd, Path):

--- a/tests/filesystem/test_find_user_home.py
+++ b/tests/filesystem/test_find_user_home.py
@@ -6,7 +6,19 @@ from pathlib import Path
 import pytest
 
 from nclutils.fs import find_user_home_dir
-from nclutils.sh import ShellCommandFailedError
+from nclutils.sh import CompletedCommand, ShellCommandFailedError
+
+
+def _make_result(stdout: str) -> CompletedCommand:
+    """Build a minimal CompletedCommand for mocking run_command."""
+    return CompletedCommand(
+        argv=(),
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+        duration=0.0,
+        cwd=None,
+    )
 
 
 @pytest.fixture
@@ -40,7 +52,7 @@ def test_find_user_home_dir_with_sudo_user(mocker):
     mocker.patch("platform.system", return_value="Linux")
     mocker.patch(
         "nclutils.fs.filesystem.run_command",
-        return_value="/home/testuser:x:1000:1000::/home/testuser:/bin/bash",
+        return_value=_make_result("/home/testuser:x:1000:1000::/home/testuser:/bin/bash"),
     )
 
     # When: Finding home directory without username
@@ -55,7 +67,7 @@ def test_find_user_home_dir_linux_success(mock_platform_linux, mocker):
     # Given: Mock successful command execution
     mocker.patch(
         "nclutils.fs.filesystem.run_command",
-        return_value="/home/testuser:x:1000:1000::/home/testuser:/bin/bash",
+        return_value=_make_result("/home/testuser:x:1000:1000::/home/testuser:/bin/bash"),
     )
 
     # When: Finding home directory for specific user
@@ -85,7 +97,7 @@ def test_find_user_home_dir_darwin_success(mock_platform_darwin, mocker):
     # Given: Mock successful command execution
     mocker.patch(
         "nclutils.fs.filesystem.run_command",
-        return_value="NFSHomeDirectory: /Users/testuser",
+        return_value=_make_result("NFSHomeDirectory: /Users/testuser"),
     )
 
     # When: Finding home directory for specific user

--- a/tests/filesystem/test_find_user_home.py
+++ b/tests/filesystem/test_find_user_home.py
@@ -70,7 +70,7 @@ def test_find_user_home_dir_linux_failure(mock_platform_linux, mocker):
     # Given: Mock failed command execution
     mocker.patch(
         "nclutils.fs.filesystem.run_command",
-        side_effect=ShellCommandFailedError("Command failed"),
+        side_effect=ShellCommandFailedError(msg="Command failed"),
     )
 
     # When: Finding home directory for non-existent user
@@ -100,7 +100,7 @@ def test_find_user_home_dir_darwin_failure(mock_platform_darwin, mocker):
     # Given: Mock failed command execution
     mocker.patch(
         "nclutils.fs.filesystem.run_command",
-        side_effect=ShellCommandFailedError("Command failed"),
+        side_effect=ShellCommandFailedError(msg="Command failed"),
     )
 
     # When: Finding home directory for non-existent user

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -256,3 +256,18 @@ class TestStreamingPump:
         with pytest.raises(UnicodeDecodeError):
             pump_pipe(pipe=reader, buffer=[], sink=None, exclude_pattern=None)
         assert reader.closed
+
+    def test_pump_pipe_partial_final_line_without_newline(self) -> None:
+        """Verify pump_pipe captures a final line that lacks a trailing newline."""
+        # Given: a pipe whose final line has no newline
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"a\nno-newline-end")
+        os.close(write_fd)
+        reader = os.fdopen(read_fd, "rb")
+        buffer: list[str] = []
+
+        # When: pumping
+        pump_pipe(pipe=reader, buffer=buffer, sink=None, exclude_pattern=None)
+
+        # Then: the trailing line is included as-is
+        assert buffer == ["a\n", "no-newline-end"]

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-import os
 import re
 from dataclasses import FrozenInstanceError
 from pathlib import Path
@@ -172,10 +171,7 @@ class TestStreamingPump:
     def test_lines_appended_to_buffer(self) -> None:
         """Verify pump_pipe decodes each line and appends it to the buffer."""
         # Given: a pipe with two lines
-        read_fd, write_fd = os.pipe()
-        os.write(write_fd, b"hello\nworld\n")
-        os.close(write_fd)
-        reader = os.fdopen(read_fd, "rb")
+        reader = io.BytesIO(b"hello\nworld\n")
         buffer: list[str] = []
 
         # When: pumping with no sink and no exclusion
@@ -188,10 +184,7 @@ class TestStreamingPump:
     def test_excluded_lines_are_dropped(self) -> None:
         """Verify lines matching exclude_pattern are omitted from buffer and sink."""
         # Given: a pipe with a kept line and a dropped line
-        read_fd, write_fd = os.pipe()
-        os.write(write_fd, b"keep me\ndrop me\n")
-        os.close(write_fd)
-        reader = os.fdopen(read_fd, "rb")
+        reader = io.BytesIO(b"keep me\ndrop me\n")
         pattern = re.compile(r"drop")
         buffer: list[str] = []
 
@@ -204,10 +197,7 @@ class TestStreamingPump:
     def test_sink_receives_lines(self) -> None:
         """Verify pump_pipe writes each non-excluded line to the sink."""
         # Given: a pipe with two lines and an in-memory sink
-        read_fd, write_fd = os.pipe()
-        os.write(write_fd, b"alpha\nbeta\n")
-        os.close(write_fd)
-        reader = os.fdopen(read_fd, "rb")
+        reader = io.BytesIO(b"alpha\nbeta\n")
         sink = io.StringIO()
         buffer: list[str] = []
 
@@ -220,9 +210,7 @@ class TestStreamingPump:
     def test_pipe_closed_on_completion(self) -> None:
         """Verify pump_pipe closes the pipe after draining it."""
         # Given: an empty pipe
-        read_fd, write_fd = os.pipe()
-        os.close(write_fd)
-        reader = os.fdopen(read_fd, "rb")
+        reader = io.BytesIO()
 
         # When: pumping an empty pipe
         pump_pipe(pipe=reader, buffer=[], sink=None, exclude_pattern=None)
@@ -233,10 +221,7 @@ class TestStreamingPump:
     def test_appends_to_existing_buffer(self) -> None:
         """Verify pump_pipe appends to an existing buffer rather than replacing it."""
         # Given: a pipe with one new line and a buffer with a pre-existing entry
-        read_fd, write_fd = os.pipe()
-        os.write(write_fd, b"new\n")
-        os.close(write_fd)
-        reader = os.fdopen(read_fd, "rb")
+        reader = io.BytesIO(b"new\n")
         buffer: list[str] = ["pre-existing\n"]
 
         # When: pumping
@@ -248,10 +233,7 @@ class TestStreamingPump:
     def test_invalid_utf8_raises_and_closes_pipe(self) -> None:
         """Verify pump_pipe surfaces UnicodeDecodeError and still closes the pipe."""
         # Given: a pipe with invalid utf-8 bytes
-        read_fd, write_fd = os.pipe()
-        os.write(write_fd, b"\xff\xfe invalid\n")
-        os.close(write_fd)
-        reader = os.fdopen(read_fd, "rb")
+        reader = io.BytesIO(b"\xff\xfe invalid\n")
 
         # When/Then: pumping raises UnicodeDecodeError and the pipe is closed afterward
         with pytest.raises(UnicodeDecodeError):
@@ -261,10 +243,7 @@ class TestStreamingPump:
     def test_pump_pipe_partial_final_line_without_newline(self) -> None:
         """Verify pump_pipe captures a final line that lacks a trailing newline."""
         # Given: a pipe whose final line has no newline
-        read_fd, write_fd = os.pipe()
-        os.write(write_fd, b"a\nno-newline-end")
-        os.close(write_fd)
-        reader = os.fdopen(read_fd, "rb")
+        reader = io.BytesIO(b"a\nno-newline-end")
         buffer: list[str] = []
 
         # When: pumping
@@ -373,10 +352,10 @@ class TestRunCommandCapture:
 
     def test_timeout_raises_timeout_error_with_partial_result(self) -> None:
         """Verify timeout= terminates the child and raises ShellCommandTimeoutError."""
-        # Given/When/Then: a long sleep with a 0.2s timeout
+        # Given/When/Then: a long sleep with a 0.05s timeout
         with pytest.raises(ShellCommandTimeoutError) as exc:
-            run_command(["sleep", "5"], timeout=0.2)
-        assert exc.value.timeout == 0.2
+            run_command(["sleep", "5"], timeout=0.05)
+        assert exc.value.timeout == 0.05
         assert exc.value.result.argv == ("sleep", "5")
 
     def test_sudo_prepends_sudo(self, mocker) -> None:
@@ -422,9 +401,9 @@ class TestRunCommandCapture:
 
     def test_invalid_utf8_in_child_output_raises(self) -> None:
         """Verify non-utf8 child output surfaces UnicodeDecodeError to the caller."""
-        # Given/When/Then: a printf that emits invalid utf-8 bytes
+        # Given/When/Then: a python child that emits invalid utf-8 bytes
         with pytest.raises(UnicodeDecodeError):
-            run_command(["printf", r"\xff\xfe"])
+            run_command(["python3", "-c", r"import sys; sys.stdout.buffer.write(b'\xff\xfe')"])
 
     def test_concurrent_stdout_and_stderr_both_captured(self) -> None:
         """Verify both stdout and stderr are captured when child writes to both."""

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -419,3 +419,28 @@ class TestRunCommandCapture:
         captured = capsys.readouterr()
         assert captured.out == ""
         assert captured.err == ""
+
+    def test_invalid_utf8_in_child_output_raises(self) -> None:
+        """Verify non-utf8 child output surfaces UnicodeDecodeError to the caller."""
+        # Given/When/Then: a printf that emits invalid utf-8 bytes
+        with pytest.raises(UnicodeDecodeError):
+            run_command(["printf", r"\xff\xfe"])
+
+    def test_concurrent_stdout_and_stderr_both_captured(self) -> None:
+        """Verify both stdout and stderr are captured when child writes to both."""
+        # Given/When: a shell command writing to both streams
+        result = run_command(["sh", "-c", "echo out; echo err >&2"])
+
+        # Then: both streams captured into the result's separate fields
+        assert "out" in result.stdout
+        assert "err" in result.stderr
+
+    def test_cwd_accepts_str_and_path(self, tmp_path: Path) -> None:
+        """Verify cwd accepts both str and Path."""
+        # Given: a tmp directory
+        # When: invoked once with str cwd, once with Path cwd
+        for cwd in (tmp_path, str(tmp_path)):
+            result = run_command(["pwd"], cwd=cwd)
+
+            # Then: both produce the same resolved cwd
+            assert result.cwd == tmp_path.resolve()

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -1,335 +1,135 @@
-"""Test shell command execution functionality."""
+"""Tests for the rewritten nclutils.sh module."""
+
+from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
 
 from nclutils.sh import (
+    CompletedCommand,
+    ShellCommandError,
     ShellCommandFailedError,
     ShellCommandNotFoundError,
-    run_command,
-    which,
+    ShellCommandTimeoutError,
 )
 
 
-def test_run_command_successful_execution(capsys: pytest.CaptureFixture) -> None:
-    """Execute a command successfully and verify output."""
-    # Given: A simple echo command
-    cmd = "echo"
-    args = ["Hello World"]
-
-    # When: Running the command
-    output = run_command(cmd, args)
-
-    # Then: Command executes successfully
-    assert "Hello World" in str(output)
-
-    # Verify console output when not quiet
-    captured = capsys.readouterr()
-    assert "Hello World" in str(captured.out)
-
-
-def test_run_command_quiet_mode(capsys: pytest.CaptureFixture) -> None:
-    """Execute a command in quiet mode and verify no console output."""
-    # Given: A simple echo command
-    cmd = "echo"
-    args = ["Hello World"]
-
-    # When: Running the command in quiet mode
-    output = run_command(cmd, args, quiet=True)
-
-    # Then: Command executes successfully but produces no console output
-    assert "Hello World" in str(output)
-    captured = capsys.readouterr()
-    assert not captured.out
-
-
-def test_run_command_fg_is_true(capsys: pytest.CaptureFixture) -> None:
-    """Execute a command in foreground mode."""
-    # Given: A simple echo command
-    cmd = "echo"
-    args = ["Hello World"]
-
-    # When: Running the command in foreground mode
-    output = run_command(cmd, args, quiet=True, fg=True)
-    captured = capsys.readouterr().err
-
-    # Then: Command executes successfully but produces no console output
-    assert not output  # No output expected in foreground mode
-    assert not captured  # A new tty is spawned for the command, so no output is captured
-
-
-def test_run_command_not_found(capsys: pytest.CaptureFixture) -> None:
-    """Handle non-existent command gracefully."""
-    # Given: A non-existent command
-    cmd = "nonexistentcommand"
-    args = []
-
-    # When: Attempting to run the command in quiet mode
-    with pytest.raises(ShellCommandNotFoundError, match="Shell command not found"):
-        run_command(cmd, args)
-
-    # Then: Command fails with appropriate error
-    captured = capsys.readouterr()
-    assert not captured.out
-
-
-def test_run_command_not_found_quiet_mode(capsys: pytest.CaptureFixture) -> None:
-    """Handle non-existent command gracefully in quiet mode."""
-    # Given: A non-existent command
-    cmd = "nonexistentcommand"
-    args = []
-
-    # When: Attempting to run the command in quiet mode
-    with pytest.raises(ShellCommandNotFoundError, match="Shell command not found"):
-        run_command(cmd, args, quiet=True)
-
-    # Then: Command fails with appropriate error
-    captured = capsys.readouterr()
-    assert not captured.out
-
-
-def test_run_command_with_error(capsys: pytest.CaptureFixture) -> None:
-    """Handle command execution errors appropriately."""
-    # Given: A command that will fail (ls with invalid path)
-    cmd = "ls"
-    args = ["/some/nonexistent/path"]
-
-    # When: Running the command
-    with pytest.raises(ShellCommandFailedError) as excinfo:
-        run_command(cmd, args, err_to_out=False)
-
-    # debug(excinfo.value.__dict__)
-
-    # Then: Command fails with non-zero return code and error message
-    assert excinfo.value.exit_code == 2
-    assert "ls /some/nonexistent/path" in excinfo.value.full_cmd
-    assert "No such file or directory" in excinfo.value.stderr
-    assert not excinfo.value.stdout
-    stderrout = capsys.readouterr().err
-    # debug(stderrout)
-    assert not stderrout
-
-
-def test_run_command_with_error_print_stderr(capsys: pytest.CaptureFixture) -> None:
-    """Handle command execution errors appropriately."""
-    # Given: A command that will fail (ls with invalid path)
-    cmd = "ls"
-    args = ["/some/nonexistent/path"]
-
-    # When: Running the command
-    with pytest.raises(ShellCommandFailedError) as excinfo:
-        run_command(cmd, args, err_to_out=True)
-
-    # debug(excinfo.value.__dict__)
-
-    # Then: Command fails with non-zero return code and error message
-    assert excinfo.value.exit_code == 2
-    assert "ls /some/nonexistent/path" in excinfo.value.full_cmd
-    assert "No such file or directory" in excinfo.value.stderr
-    assert not excinfo.value.stdout
-    stdout = capsys.readouterr().out
-
-    assert "ls: cannot access '/some/nonexistent/path': No such file or directory" in stdout
-
-
-def test_run_command_with_error_quiet_mode(capsys: pytest.CaptureFixture) -> None:
-    """Handle command execution errors appropriately in quiet mode."""
-    # Given: A command that will fail (ls with invalid path)
-    cmd = "ls"
-    args = ["/some/nonexistent/path"]
-
-    # When: Running the command
-    with pytest.raises(ShellCommandFailedError) as excinfo:
-        run_command(cmd, args, quiet=True)
-
-    # Then: Command fails with non-zero return code and error message
-    assert excinfo.value.exit_code == 2
-    assert "ls /some/nonexistent/path" in excinfo.value.full_cmd
-    assert "No such file or directory" in excinfo.value.stderr
-    assert not excinfo.value.stdout
-    captured = capsys.readouterr()
-    assert not captured.out
-
-
-def test_which_success() -> None:
-    """Test the which function with a successful command."""
-    # Given: A command that exists in the PATH
-    cmd = "ls"
-    # When: Running the command
-    result = which(cmd)
-    # Then: The command exists in the PATH
-    assert result is not None
-    assert isinstance(result, str)
-    assert result.strip()
-    assert Path(result).exists()
-
-
-def test_which_failure() -> None:
-    """Test the which function with a command that does not exist in the PATH."""
-    # Given: A command that does not exist in the PATH
-    cmd = "nonexistentcommand"
-
-    # When: Running the command
-    result = which(cmd)
-
-    # Then: The command does not exist in the PATH
-    assert result is None
-
-
-def test_run_command_with_pushd(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-    """Execute a command in a different directory using pushd."""
-    # Given: A temporary directory and pwd command
-    cmd = "pwd"
-    original_dir = Path.cwd()
-
-    # When: Running the command with pushd
-    output = run_command(cmd, [], pushd=str(tmp_path))
-
-    # Then: Command executes in the specified directory
-    assert str(tmp_path) in str(output).replace("\r", "").replace("\n", "")
-    assert Path.cwd() == original_dir
-    captured = capsys.readouterr()
-    assert str(tmp_path) in captured.out.replace("\r", "").replace("\n", "")
-
-
-def test_run_command_with_pushd_quiet_mode(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-    """Execute a command with pushd in quiet mode."""
-    cmd = "pwd"
-    original_dir = Path.cwd()
-
-    # When: Running the command with pushd
-    output = run_command(cmd, [], pushd=tmp_path, quiet=True)
-
-    # Then: Command executes in the specified directory
-    assert str(tmp_path) in str(output).replace("\r", "").replace("\n", "")
-    assert Path.cwd() == original_dir
-    captured = capsys.readouterr()
-    assert not captured.out
-
-
-def test_run_command_with_pushd_nonexistent_dir(capsys: pytest.CaptureFixture) -> None:
-    """Handle pushd to nonexistent directory gracefully."""
-    # Given: A nonexistent directory
-    nonexistent_dir = Path("/some/nonexistent/directory")
-    cmd = "pwd"
-
-    # When/Then: Running command with invalid pushd raises error
-    with pytest.raises(ShellCommandFailedError, match=r"Cannot enter directory"):
-        run_command(cmd, [], pushd=nonexistent_dir)
-
-    captured = capsys.readouterr()
-    assert not captured.out
-
-
-def test_exclude_lines(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-    """Test the exclude_lines parameter."""
-    # Given: A temporary file
-    tmpfile = tmp_path / "tmpfile.txt"
-    tmpfile.write_text("hello world\nworking... 0%\nworking... 10%\ndone")
-
-    # When: Running the command
-    output = run_command("cat", [str(tmpfile)], exclude_regex=r"\d+%$")
-
-    captured = capsys.readouterr().out
-
-    # Then: The command executes successfully
-    assert "hello world" in str(captured)
-    assert "working... 0%" not in str(captured)
-    assert "working... 10%" not in str(captured)
-    assert "done" in str(captured)
-    assert "hello world" in str(output)
-    assert "working... 0%" not in str(output)
-    assert "working... 10%" not in str(output)
-    assert "done" in str(output)
-
-
-@pytest.mark.parametrize(
-    ("codes", "should_raise"),
-    [
-        ((0, 1), False),
-        ((0,), True),
-    ],
-)
-def test_run_command_okay_codes_whitelist(codes: tuple[int, ...], *, should_raise: bool) -> None:
-    """Verify okay_codes whitelists non-zero exit codes."""
-    # Given: A grep that exits 1 because no line matches
-    cmd = "grep"
-    args = ["pattern_that_will_not_match", "/dev/null"]
-
-    # When/Then: The exit code raises only when not in okay_codes
-    if should_raise:
-        with pytest.raises(ShellCommandFailedError) as excinfo:
-            run_command(cmd, args, okay_codes=codes, quiet=True)
-        assert excinfo.value.exit_code == 1
-    else:
-        result = run_command(cmd, args, okay_codes=codes, quiet=True)
-        assert result == ""
-
-
-def test_run_command_fg_passes_fg_kwarg_to_sh(mocker: MockerFixture) -> None:
-    """Verify fg=True forwards _fg=True to sh.Command and skips capture kwargs."""
-    # Given: sh.Command is mocked so the underlying invocation is intercepted
-    mock_cmd_class = mocker.patch("nclutils.sh.shell_command.sh.Command")
-
-    # When: Running with fg=True
-    run_command("echo", ["test"], fg=True)
-
-    # Then: The command was called with _fg=True and without capture callbacks
-    mock_cmd_class.assert_called_once_with("echo")
-    cmd_instance = mock_cmd_class.return_value
-    cmd_instance.assert_called_once()
-    call_kwargs = cmd_instance.call_args.kwargs
-    assert call_kwargs.get("_fg") is True
-    assert "_out" not in call_kwargs
-    assert "_err" not in call_kwargs
-    assert "_tee" not in call_kwargs
-
-
-@pytest.fixture
-def stub_sh(mocker: MockerFixture):
-    """Stub sh.contrib (a property — can't patch sh.contrib.sudo directly) and sh.Command."""
-    fake_contrib = mocker.MagicMock()
-    mocker.patch("nclutils.sh.shell_command.sh.contrib", new=fake_contrib)
-    mocker.patch("nclutils.sh.shell_command.sh.Command")
-    return fake_contrib
-
-
-def test_run_command_with_sudo_enters_sudo_context(stub_sh) -> None:
-    """Verify sudo=True wraps execution in sh.contrib.sudo(_with=True)."""
-    # When: Running with sudo=True
-    run_command("echo", ["hello"], sudo=True, quiet=True)
-
-    # Then: sudo was invoked with _with=True and entered as a context manager.
-    # The absence of k=True is enforced by assert_called_once_with's exact-match.
-    stub_sh.sudo.assert_called_once_with(_with=True)
-    stub_sh.sudo.return_value.__enter__.assert_called_once()
-
-
-def test_run_command_without_sudo_does_not_enter_sudo_context(stub_sh) -> None:
-    """Verify sudo=False leaves sh.contrib.sudo untouched."""
-    # When: Running without sudo
-    run_command("echo", ["hello"], quiet=True)
-
-    # Then: sudo was never invoked
-    stub_sh.sudo.assert_not_called()
-
-
-def test_run_command_err_to_out_false_drops_successful_stderr(
-    capsys: pytest.CaptureFixture,
-) -> None:
-    """Verify err_to_out=False suppresses stderr from a successful command."""
-    # Given: A successful command emitting both stdout and stderr
-    cmd = "sh"
-    args = ["-c", "echo OUTLINE; echo ERRLINE >&2"]
-
-    # When: Running with err_to_out=False
-    output = run_command(cmd, args, err_to_out=False)
-
-    # Then: stderr is absent from both the captured return value and the streamed console
-    assert "OUTLINE" in output
-    assert "ERRLINE" not in output
-    captured = capsys.readouterr()
-    assert "OUTLINE" in captured.out
-    assert "ERRLINE" not in captured.out
+class TestCompletedCommand:
+    """Tests for the CompletedCommand dataclass."""
+
+    def test_fields_and_ok_property(self) -> None:
+        """Verify CompletedCommand exposes argv/returncode/stdout/stderr/duration/cwd and ok."""
+        # Given: a CompletedCommand built with returncode 0
+        result = CompletedCommand(
+            argv=("echo", "hi"),
+            returncode=0,
+            stdout="hi\n",
+            stderr="",
+            duration=0.01,
+            cwd=Path("/tmp"),  # noqa: S108
+        )
+
+        # Then: every field is reachable and ok is True
+        assert result.argv == ("echo", "hi")
+        assert result.returncode == 0
+        assert result.stdout == "hi\n"
+        assert result.stderr == ""
+        assert result.duration == 0.01
+        assert result.cwd == Path("/tmp")  # noqa: S108
+        assert result.ok is True
+
+    def test_ok_false_on_nonzero(self) -> None:
+        """Verify ok is False when returncode is non-zero."""
+        # Given: a CompletedCommand with returncode 2
+        result = CompletedCommand(
+            argv=("false",),
+            returncode=2,
+            stdout="",
+            stderr="",
+            duration=0.0,
+            cwd=None,
+        )
+
+        # Then: ok is False
+        assert result.ok is False
+
+    def test_frozen_and_hashable(self) -> None:
+        """Verify CompletedCommand is frozen and hashable."""
+        # Given: a CompletedCommand
+        result = CompletedCommand(
+            argv=("ls",), returncode=0, stdout="", stderr="", duration=0.0, cwd=None
+        )
+
+        # When: attempting to mutate, it raises; hashing succeeds
+        with pytest.raises(Exception):  # noqa: B017, PT011  # FrozenInstanceError or AttributeError
+            result.returncode = 1  # type: ignore[misc]
+        assert isinstance(hash(result), int)
+
+
+class TestErrorHierarchy:
+    """Tests for the unified ShellCommandError hierarchy."""
+
+    def test_all_subclasses_inherit_from_base(self) -> None:
+        """Verify every concrete error inherits from ShellCommandError."""
+        # Given: the three concrete error classes
+        # Then: each is a subclass of the base
+        assert issubclass(ShellCommandNotFoundError, ShellCommandError)
+        assert issubclass(ShellCommandFailedError, ShellCommandError)
+        assert issubclass(ShellCommandTimeoutError, ShellCommandError)
+
+    def test_failed_carries_result(self) -> None:
+        """Verify ShellCommandFailedError exposes the CompletedCommand it would have returned."""
+        # Given: a CompletedCommand and an error built from it
+        result = CompletedCommand(
+            argv=("git", "push"),
+            returncode=1,
+            stdout="",
+            stderr="rejected",
+            duration=0.5,
+            cwd=Path("/tmp"),  # noqa: S108
+        )
+        err = ShellCommandFailedError(result=result)
+
+        # Then: the result is reachable via attribute and the message includes context
+        assert err.result is result
+        assert "git push" in str(err)
+        assert "exit code 1" in str(err)
+        assert "rejected" in str(err)
+
+    def test_failed_with_no_result_for_cwd_error(self) -> None:
+        """Verify ShellCommandFailedError accepts result=None when cwd was unreachable."""
+        # Given: an error raised before the command ran
+        err = ShellCommandFailedError(
+            msg="Cannot enter directory /no/such/dir: not a directory", result=None
+        )
+
+        # Then: result is None and the message is preserved
+        assert err.result is None
+        assert "Cannot enter directory /no/such/dir" in str(err)
+
+    def test_timeout_carries_partial_result(self) -> None:
+        """Verify ShellCommandTimeoutError exposes partial output and the exceeded timeout."""
+        # Given: partial output captured before kill and a 1.5s timeout
+        partial = CompletedCommand(
+            argv=("sleep", "10"),
+            returncode=-9,
+            stdout="started\n",
+            stderr="",
+            duration=1.5,
+            cwd=None,
+        )
+        err = ShellCommandTimeoutError(result=partial, timeout=1.5)
+
+        # Then: the partial result and the timeout value are both reachable
+        assert err.result is partial
+        assert err.timeout == 1.5
+        assert "1.5" in str(err)
+
+    def test_not_found_message_uses_argv(self) -> None:
+        """Verify ShellCommandNotFoundError reports the missing executable name."""
+        # Given: an error built for a missing binary
+        err = ShellCommandNotFoundError(argv=("not-a-real-command", "--help"))
+
+        # Then: the executable name is in the message
+        assert "not-a-real-command" in str(err)

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -16,6 +16,7 @@ from nclutils.sh import (
     ShellCommandFailedError,
     ShellCommandNotFoundError,
     ShellCommandTimeoutError,
+    run_command,
     which,
 )
 from nclutils.sh._streaming import pump_pipe
@@ -271,3 +272,150 @@ class TestStreamingPump:
 
         # Then: the trailing line is included as-is
         assert buffer == ["a\n", "no-newline-end"]
+
+
+class TestRunCommandCapture:
+    """Tests for run_command without stream=True (capture only)."""
+
+    def test_returns_completed_command_on_success(self) -> None:
+        """Verify run_command returns a CompletedCommand with stdout, returncode, and argv."""
+        # Given/When: a successful echo
+        result = run_command(["echo", "hello"])
+
+        # Then: a CompletedCommand with hello on stdout and exit 0
+        assert isinstance(result, CompletedCommand)
+        assert result.returncode == 0
+        assert result.argv == ("echo", "hello")
+        assert "hello" in result.stdout
+        assert result.stderr == ""
+        assert result.duration >= 0
+        assert result.ok is True
+
+    def test_check_true_raises_failed_on_nonzero(self) -> None:
+        """Verify check=True raises ShellCommandFailedError carrying the result."""
+        # Given/When: a command that exits 1
+        # Then: ShellCommandFailedError is raised and exposes the result
+        with pytest.raises(ShellCommandFailedError) as exc:
+            run_command(["false"])
+        assert exc.value.result is not None
+        assert exc.value.result.returncode == 1
+        assert exc.value.result.argv == ("false",)
+
+    def test_check_false_returns_nonzero_result(self) -> None:
+        """Verify check=False suppresses raising and returns the failed result."""
+        # Given/When: a failing command with check=False
+        result = run_command(["false"], check=False)
+
+        # Then: result is returned, returncode is non-zero
+        assert result.returncode != 0
+        assert result.ok is False
+
+    def test_okay_codes_treats_listed_codes_as_success(self) -> None:
+        """Verify a returncode in okay_codes does not raise."""
+        # Given/When: false (rc=1) with 0 and 1 both okay
+        result = run_command(["false"], okay_codes=(0, 1))
+
+        # Then: returns normally
+        assert result.returncode == 1
+
+    def test_command_not_found_raises(self) -> None:
+        """Verify a missing executable raises ShellCommandNotFoundError."""
+        # Given/When/Then: a non-existent binary raises NotFound
+        with pytest.raises(ShellCommandNotFoundError):
+            run_command(["definitely-not-a-real-binary-xyz-12345"])
+
+    def test_cwd_changes_directory(self, tmp_path: Path) -> None:
+        """Verify cwd= runs the command from the given directory."""
+        # Given: a subdir containing one file
+        (tmp_path / "marker.txt").write_text("hi")
+
+        # When: running ls under cwd=tmp_path
+        result = run_command(["ls"], cwd=tmp_path)
+
+        # Then: marker.txt appears in stdout
+        assert "marker.txt" in result.stdout
+        assert result.cwd == tmp_path.resolve()
+
+    def test_cwd_unreachable_raises_failed(self) -> None:
+        """Verify a missing cwd raises ShellCommandFailedError with result=None."""
+        # Given/When/Then: a non-existent dir raises Failed with no result
+        with pytest.raises(ShellCommandFailedError) as exc:
+            run_command(["echo", "hi"], cwd="/no/such/dir/xyz")
+        assert exc.value.result is None
+        assert "/no/such/dir/xyz" in str(exc.value)
+
+    def test_env_replaces_environment(self) -> None:
+        """Verify env= replaces (does not extend) the child environment."""
+        # Given/When: a fully replaced env containing only FOO=bar
+        result = run_command(
+            ["sh", "-c", "echo $FOO"],
+            env={"FOO": "bar", "PATH": "/usr/bin:/bin"},
+        )
+
+        # Then: FOO is bar
+        assert result.stdout.strip() == "bar"
+
+    def test_input_str_is_written_to_stdin(self) -> None:
+        """Verify input= writes a string to the child's stdin and is read back via cat."""
+        # Given/When: cat reads stdin
+        result = run_command(["cat"], input="ping pong")
+
+        # Then: the same text comes back on stdout
+        assert result.stdout == "ping pong"
+
+    def test_input_bytes_is_passed_through(self) -> None:
+        """Verify input= accepts bytes and forwards them verbatim."""
+        # Given/When: bytes input
+        result = run_command(["cat"], input=b"raw bytes\n")
+
+        # Then: stdout matches the bytes decoded as utf-8
+        assert result.stdout == "raw bytes\n"
+
+    def test_timeout_raises_timeout_error_with_partial_result(self) -> None:
+        """Verify timeout= terminates the child and raises ShellCommandTimeoutError."""
+        # Given/When/Then: a long sleep with a 0.2s timeout
+        with pytest.raises(ShellCommandTimeoutError) as exc:
+            run_command(["sleep", "5"], timeout=0.2)
+        assert exc.value.timeout == 0.2
+        assert exc.value.result.argv == ("sleep", "5")
+
+    def test_sudo_prepends_sudo(self, mocker) -> None:
+        """Verify sudo=True prepends 'sudo' to argv before invocation."""
+        # Given: a Popen mock that records argv
+        from nclutils.sh import shell_command as sc  # noqa: PLC0415
+
+        recorded: dict = {}
+
+        class FakeProc:
+            def __init__(self, argv: list[str], **kwargs: object) -> None:
+                recorded["argv"] = argv
+                self.stdout = mocker.MagicMock()
+                self.stdout.readline.side_effect = [b""]
+                self.stderr = mocker.MagicMock()
+                self.stderr.readline.side_effect = [b""]
+                self.stdin = None
+                self.returncode = 0
+
+            def wait(self, timeout: float | None = None) -> int:
+                return 0
+
+            def kill(self) -> None:
+                pass
+
+        mocker.patch.object(sc.subprocess, "Popen", autospec=True, side_effect=FakeProc)
+
+        # When: running with sudo=True
+        run_command(["whoami"], sudo=True)
+
+        # Then: argv was prefixed
+        assert recorded["argv"][:2] == ["sudo", "whoami"]
+
+    def test_quiet_by_default_does_not_print(self, capsys: pytest.CaptureFixture) -> None:
+        """Verify the default (stream=False) writes nothing to sys.stdout/sys.stderr."""
+        # Given/When: a successful echo with default stream=False
+        run_command(["echo", "hello"])
+
+        # Then: nothing leaked to capsys
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -27,7 +28,7 @@ class TestCompletedCommand:
             stdout="hi\n",
             stderr="",
             duration=0.01,
-            cwd=Path("/tmp"),  # noqa: S108
+            cwd=Path("/some/cwd"),
         )
 
         # Then: every field is reachable and ok is True
@@ -36,7 +37,7 @@ class TestCompletedCommand:
         assert result.stdout == "hi\n"
         assert result.stderr == ""
         assert result.duration == 0.01
-        assert result.cwd == Path("/tmp")  # noqa: S108
+        assert result.cwd == Path("/some/cwd")
         assert result.ok is True
 
     def test_ok_false_on_nonzero(self) -> None:
@@ -62,7 +63,7 @@ class TestCompletedCommand:
         )
 
         # When: attempting to mutate, it raises; hashing succeeds
-        with pytest.raises(Exception):  # noqa: B017, PT011  # FrozenInstanceError or AttributeError
+        with pytest.raises(FrozenInstanceError):
             result.returncode = 1  # type: ignore[misc]
         assert isinstance(hash(result), int)
 
@@ -87,7 +88,7 @@ class TestErrorHierarchy:
             stdout="",
             stderr="rejected",
             duration=0.5,
-            cwd=Path("/tmp"),  # noqa: S108
+            cwd=Path("/some/cwd"),
         )
         err = ShellCommandFailedError(result=result)
 

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -499,3 +499,94 @@ class TestRunCommandStreaming:
         assert "a\n" in result.stdout
         assert "b" not in result.stdout
         assert "c\n" in result.stdout
+
+
+class TestRunInteractive:
+    """Tests for run_interactive."""
+
+    def test_returns_exit_code_on_success(self, mocker) -> None:
+        """Verify run_interactive returns the child's exit code without capture."""
+        # Given: a Popen mock that exits 0
+        from nclutils.sh import run_interactive  # noqa: PLC0415
+        from nclutils.sh import shell_command as sc  # noqa: PLC0415
+
+        fake = mocker.MagicMock()
+        fake.wait.return_value = 0
+        fake.returncode = 0
+        mocker.patch.object(sc.subprocess, "Popen", autospec=True, return_value=fake)
+
+        # When: invoking
+        rc = run_interactive(["true"])
+
+        # Then: the returncode is returned
+        assert rc == 0
+
+    def test_inherits_parent_stdio(self, mocker) -> None:
+        """Verify run_interactive does not pass stdin/stdout/stderr=PIPE."""
+        # Given: a Popen mock
+        from nclutils.sh import run_interactive  # noqa: PLC0415
+        from nclutils.sh import shell_command as sc  # noqa: PLC0415
+
+        fake = mocker.MagicMock()
+        fake.wait.return_value = 0
+        fake.returncode = 0
+        popen = mocker.patch.object(sc.subprocess, "Popen", autospec=True, return_value=fake)
+
+        # When: invoking
+        run_interactive(["vim"])
+
+        # Then: Popen was called without stdout=PIPE / stderr=PIPE
+        kwargs = popen.call_args.kwargs
+        assert "stdout" not in kwargs or kwargs["stdout"] is None
+        assert "stderr" not in kwargs or kwargs["stderr"] is None
+
+    def test_check_true_raises_failed_on_nonzero(self, mocker) -> None:
+        """Verify check=True raises ShellCommandFailedError for non-zero exits."""
+        # Given: a Popen mock that exits 1
+        from nclutils.sh import run_interactive  # noqa: PLC0415
+        from nclutils.sh import shell_command as sc  # noqa: PLC0415
+
+        fake = mocker.MagicMock()
+        fake.wait.return_value = 1
+        fake.returncode = 1
+        mocker.patch.object(sc.subprocess, "Popen", autospec=True, return_value=fake)
+
+        # When/Then: check=True (default) raises
+        with pytest.raises(ShellCommandFailedError) as exc:
+            run_interactive(["false"])
+        assert exc.value.result is not None
+        assert exc.value.result.returncode == 1
+
+    def test_check_false_returns_nonzero(self, mocker) -> None:
+        """Verify check=False returns the exit code without raising."""
+        # Given: a Popen mock that exits 1
+        from nclutils.sh import run_interactive  # noqa: PLC0415
+        from nclutils.sh import shell_command as sc  # noqa: PLC0415
+
+        fake = mocker.MagicMock()
+        fake.wait.return_value = 1
+        fake.returncode = 1
+        mocker.patch.object(sc.subprocess, "Popen", autospec=True, return_value=fake)
+
+        # When: check=False
+        rc = run_interactive(["false"], check=False)
+
+        # Then: returns 1
+        assert rc == 1
+
+    def test_sudo_prepends(self, mocker) -> None:
+        """Verify sudo=True prepends sudo to argv."""
+        # Given: a Popen mock recording argv
+        from nclutils.sh import run_interactive  # noqa: PLC0415
+        from nclutils.sh import shell_command as sc  # noqa: PLC0415
+
+        fake = mocker.MagicMock()
+        fake.wait.return_value = 0
+        fake.returncode = 0
+        popen = mocker.patch.object(sc.subprocess, "Popen", autospec=True, return_value=fake)
+
+        # When: running with sudo=True
+        run_interactive(["whoami"], sudo=True)
+
+        # Then: argv prefixed
+        assert popen.call_args.args[0][:2] == ["sudo", "whoami"]

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import io
+import os
+import re
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 
@@ -15,6 +18,7 @@ from nclutils.sh import (
     ShellCommandTimeoutError,
     which,
 )
+from nclutils.sh._streaming import pump_pipe
 
 
 class TestCompletedCommand:
@@ -159,3 +163,96 @@ class TestWhich:
 
         # Then: None
         assert result is None
+
+
+class TestStreamingPump:
+    """Tests for pump_pipe."""
+
+    def test_lines_appended_to_buffer(self) -> None:
+        """Verify pump_pipe decodes each line and appends it to the buffer."""
+        # Given: a pipe with two lines
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"hello\nworld\n")
+        os.close(write_fd)
+        reader = os.fdopen(read_fd, "rb")
+        buffer: list[str] = []
+
+        # When: pumping with no sink and no exclusion
+        pump_pipe(pipe=reader, buffer=buffer, sink=None, exclude_pattern=None)
+
+        # Then: both lines are in the buffer and the pipe is closed
+        assert buffer == ["hello\n", "world\n"]
+        assert reader.closed
+
+    def test_excluded_lines_are_dropped(self) -> None:
+        """Verify lines matching exclude_pattern are omitted from buffer and sink."""
+        # Given: a pipe with a kept line and a dropped line
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"keep me\ndrop me\n")
+        os.close(write_fd)
+        reader = os.fdopen(read_fd, "rb")
+        pattern = re.compile(r"drop")
+        buffer: list[str] = []
+
+        # When: pumping with an exclusion pattern
+        pump_pipe(pipe=reader, buffer=buffer, sink=None, exclude_pattern=pattern)
+
+        # Then: only the kept line survives
+        assert buffer == ["keep me\n"]
+
+    def test_sink_receives_lines(self) -> None:
+        """Verify pump_pipe writes each non-excluded line to the sink."""
+        # Given: a pipe with two lines and an in-memory sink
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"alpha\nbeta\n")
+        os.close(write_fd)
+        reader = os.fdopen(read_fd, "rb")
+        sink = io.StringIO()
+        buffer: list[str] = []
+
+        # When: pumping with a sink
+        pump_pipe(pipe=reader, buffer=buffer, sink=sink, exclude_pattern=None)
+
+        # Then: the sink contains both lines
+        assert sink.getvalue() == "alpha\nbeta\n"
+
+    def test_pipe_closed_on_completion(self) -> None:
+        """Verify pump_pipe closes the pipe after draining it."""
+        # Given: an empty pipe
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        reader = os.fdopen(read_fd, "rb")
+
+        # When: pumping an empty pipe
+        pump_pipe(pipe=reader, buffer=[], sink=None, exclude_pattern=None)
+
+        # Then: the pipe is closed
+        assert reader.closed
+
+    def test_appends_to_existing_buffer(self) -> None:
+        """Verify pump_pipe appends to an existing buffer rather than replacing it."""
+        # Given: a pipe with one new line and a buffer with a pre-existing entry
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"new\n")
+        os.close(write_fd)
+        reader = os.fdopen(read_fd, "rb")
+        buffer: list[str] = ["pre-existing\n"]
+
+        # When: pumping
+        pump_pipe(pipe=reader, buffer=buffer, sink=None, exclude_pattern=None)
+
+        # Then: the new line is appended after the pre-existing one
+        assert buffer == ["pre-existing\n", "new\n"]
+
+    def test_invalid_utf8_raises_and_closes_pipe(self) -> None:
+        """Verify pump_pipe surfaces UnicodeDecodeError and still closes the pipe."""
+        # Given: a pipe with invalid utf-8 bytes
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b"\xff\xfe invalid\n")
+        os.close(write_fd)
+        reader = os.fdopen(read_fd, "rb")
+
+        # When/Then: pumping raises UnicodeDecodeError and the pipe is closed afterward
+        with pytest.raises(UnicodeDecodeError):
+            pump_pipe(pipe=reader, buffer=[], sink=None, exclude_pattern=None)
+        assert reader.closed

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -13,6 +13,7 @@ from nclutils.sh import (
     ShellCommandFailedError,
     ShellCommandNotFoundError,
     ShellCommandTimeoutError,
+    which,
 )
 
 
@@ -134,3 +135,27 @@ class TestErrorHierarchy:
 
         # Then: the executable name is in the message
         assert "not-a-real-command" in str(err)
+
+
+class TestWhich:
+    """Tests for which()."""
+
+    def test_returns_path_for_known_binary(self) -> None:
+        """Verify which() returns an absolute Path for a binary that exists."""
+        # Given: a binary that's reliably on PATH everywhere
+        # When: looking up sh
+        result = which("sh")
+
+        # Then: an absolute Path is returned
+        assert result is not None
+        assert isinstance(result, Path)
+        assert result.is_absolute()
+
+    def test_returns_none_for_unknown_binary(self) -> None:
+        """Verify which() returns None when the binary isn't on PATH."""
+        # Given: a name that won't exist on any system
+        # When: looking it up
+        result = which("definitely-not-a-real-binary-xyz-12345")
+
+        # Then: None
+        assert result is None

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -444,3 +444,58 @@ class TestRunCommandCapture:
 
             # Then: both produce the same resolved cwd
             assert result.cwd == tmp_path.resolve()
+
+
+class TestRunCommandStreaming:
+    """Tests for stream=True and exclude_regex."""
+
+    def test_stream_true_writes_stdout_live(self, capsys: pytest.CaptureFixture) -> None:
+        """Verify stream=True tees stdout to sys.stdout while still capturing it."""
+        # Given/When: a streamed echo
+        result = run_command(["echo", "streamed"], stream=True)
+        captured = capsys.readouterr()
+
+        # Then: live output and captured output both contain the line
+        assert "streamed" in captured.out
+        assert "streamed" in result.stdout
+
+    def test_stream_true_writes_stderr_live(self, capsys: pytest.CaptureFixture) -> None:
+        """Verify stream=True tees stderr to sys.stderr."""
+        # Given/When: a command that writes to stderr
+        result = run_command(["sh", "-c", "echo errline 1>&2"], stream=True)
+        captured = capsys.readouterr()
+
+        # Then: live stderr saw the line, captured stderr too
+        assert "errline" in captured.err
+        assert "errline" in result.stderr
+
+    def test_exclude_regex_drops_from_capture_and_stream(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Verify exclude_regex removes matching lines from both stream and capture."""
+        # Given/When: noisy output with a regex matching the noise
+        result = run_command(
+            ["sh", "-c", "echo keep; echo drop me; echo also keep"],
+            stream=True,
+            exclude_regex=r"^drop",
+        )
+        captured = capsys.readouterr()
+
+        # Then: noise gone from both
+        assert "drop me" not in captured.out
+        assert "drop me" not in result.stdout
+        assert "keep" in result.stdout
+        assert "also keep" in result.stdout
+
+    def test_exclude_regex_applies_when_stream_false(self) -> None:
+        """Verify exclude_regex still filters captured output when stream=False."""
+        # Given/When: filter without streaming
+        result = run_command(
+            ["sh", "-c", "echo a; echo b; echo c"],
+            exclude_regex=r"^b$",
+        )
+
+        # Then: b is gone from capture
+        assert "a\n" in result.stdout
+        assert "b" not in result.stdout
+        assert "c\n" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -677,7 +677,6 @@ source = { editable = "." }
 dependencies = [
     { name = "questionary" },
     { name = "rich" },
-    { name = "sh" },
 ]
 
 [package.dev-dependencies]
@@ -705,7 +704,6 @@ dev = [
 requires-dist = [
     { name = "questionary", specifier = ">=2.1.1" },
     { name = "rich", specifier = ">=15.0.0" },
-    { name = "sh", specifier = ">=2.2.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1082,15 +1080,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
-]
-
-[[package]]
-name = "sh"
-version = "2.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/59/52/f43920223c93e31874677c681b8603d36a40d3d8502d3a37f80d3995d43e/sh-2.2.2.tar.gz", hash = "sha256:653227a7c41a284ec5302173fbc044ee817c7bad5e6e4d8d55741b9aeb9eb65b", size = 345866, upload-time = "2025-02-24T07:16:25.363Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/98/d82f14ac7ffedbd38dfa2383f142b26d18d23ca6cf35a40f4af60df666bd/sh-2.2.2-py3-none-any.whl", hash = "sha256:e0b15b4ae8ffcd399bc8ffddcbd770a43c7a70a24b16773fbb34c001ad5d52af", size = 38295, upload-time = "2025-02-24T07:16:23.782Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Hard-break rewrite of `nclutils.sh`, replacing the third-party `sh` library with stdlib `subprocess`. Public API is reshaped around a structured return type and a unified error hierarchy.

- `run_command(argv, *, cwd, env, input, timeout, exclude_regex, stream, check, okay_codes, sudo) -> CompletedCommand` — single argv list, structured return.
- `run_interactive(argv, *, cwd, env, sudo, check) -> int` — for tty-driving commands (vim, less, ssh).
- `which(cmd) -> Path | None` — `Path` instead of `str`.
- `CompletedCommand` (frozen dataclass): `argv`, `returncode`, `stdout`, `stderr`, `duration`, `cwd`, `ok`.
- Unified error tree: `ShellCommandError` (base), `ShellCommandNotFoundError`, `ShellCommandFailedError`, `ShellCommandTimeoutError`. `Failed` and `Timeout` carry a `result: CompletedCommand`.
- Internal `nclutils.fs.filesystem` callers migrated.
- `sh>=2.2.2` dropped from `pyproject.toml`.
- `docs/shell_commands.md` rewritten with a migration table; project-wide docs cleanup (em dashes out, GFM admonitions).

This is intentionally a hard break with no deprecation cycle. The migration table at `docs/shell_commands.md` covers every renamed kwarg, the return-type change, and the error-attribute remapping (`e.exit_code` → `e.result.returncode`, etc.).

## Test plan

- [x] `duty test` green (290 passed)
- [x] `duty lint` green (ruff + ruff format + mypy + typos + pre-commit hooks)
- [x] mypy clean across all 22 source files
- [x] Coverage 96.4% project-wide; 97.9% on the `nclutils.sh` module
- [x] Manual smoke: `run_command(["git", "status"])`, `run_command(["false"], check=False)`, `which("git")`, `run_command(["sleep", "5"], timeout=0.05)`, `run_command(["sh", "-c", "echo a; echo b >&2"])` with separate streams
- [ ] Reviewer to verify the migration table catches every kwarg/attribute they actually use