### PR TITLE
refactor(fs)!: _Copier class, strict kwarg, unified progress

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -45,8 +45,8 @@ copy_file(src, dst, with_progress=True, console=console())
 > [!NOTE]
 > `copy_directory` requires Python 3.12+ because it uses `Path.walk()`. Calling it on an older interpreter raises `ValueError`.
 
-> [!WARNING]
-> Refusing to copy is silent. Same source and destination, or copying a directory into itself or its parent, returns the source path and logs a warning rather than raising. Check the return value or watch the `nclutils.fs` logger if this matters.
+> [!NOTE]
+> By default, same-source-and-destination and parent/child copy attempts return the source path and log a warning. Pass `strict=True` to raise `shutil.SameFileError` or `ValueError` instead.
 
 > [!NOTE]
 > `copy_file` raises `IsADirectoryError` when the source is a directory and `OSError` for any other non-regular file. `~` is expanded in both `src` and `dst` before validation, so `Path("~/foo")` resolves correctly. `copy_directory` preserves the source directory's permission bits (mode) through `shutil.copystat`; modification times are not preserved because file writes during copy bump the mirrored directory's mtime.
@@ -68,7 +68,7 @@ backup = backup_path(original)
 backup_path(original, backup_suffix=".pre-migration.bak")
 ```
 
-By default `backup_path` returns `None` when the source doesn't exist. Pass `raise_on_missing=True` to make a missing source an error instead.
+By default `backup_path` returns `None` when the source doesn't exist. Pass `strict=True` to raise `FileNotFoundError` instead.
 
 > [!NOTE]
 > File backups preserve the source's permission bits (mode). Directory backups inherit mode and timestamps via `shutil.copytree`.
@@ -84,7 +84,7 @@ from nclutils.fs import clean_directory
 clean_directory(Path("./tmp"))
 ```
 
-If the path isn't an existing directory, the call is a no-op and a warning is logged. Symlinks inside the directory (including dangling links and links pointing at directories) are removed via `unlink()`; their targets are not modified.
+If the path isn't an existing directory, the call is a no-op and a warning is logged. Pass `strict=True` to raise `NotADirectoryError` instead. Symlinks inside the directory (including dangling links and links pointing at directories) are removed via `unlink()`; their targets are not modified.
 
 ## Searching
 
@@ -168,7 +168,7 @@ find_user_home_dir()
 find_user_home_dir("alice")
 ```
 
-Returns `None` if the user isn't found, or if the platform does not provide `pwd` (Windows). On platforms without `pwd` a warning is logged.
+Returns `None` if the user isn't found, or if the platform does not provide `pwd` (Windows). Pass `strict=True` to raise `KeyError` when the user is unknown. The `pwd` unavailability path always returns `None` regardless of `strict`, since it represents a platform limitation rather than a runtime error. On platforms without `pwd` a warning is logged.
 
 ## Diagnostic logging
 
@@ -184,11 +184,11 @@ This is independent of `nclutils.pretty_print`. It covers internal operations li
 
 ## API reference
 
-- `backup_path(src, backup_suffix="", *, raise_on_missing=False, with_progress=False, transient=True, console=None)`. Snapshot a file or directory with a timestamped suffix, preserving the source's permission bits.
-- `clean_directory(directory)`. Recursively empty a directory in place.
-- `copy_file(src, dst, *, with_progress=False, transient=True, keep_backup=True, console=None)`. Copy a file with optional progress and destination backup. Raises `IsADirectoryError` if `src` is a directory.
-- `copy_directory(src, dst, *, with_progress=False, transient=True, keep_backup=True, console=None)`. Recursively copy a directory, preserving directory permission bits. Requires Python 3.12+.
+- `backup_path(src, backup_suffix="", *, with_progress=False, transient=True, console=None, strict=False)`. Snapshot a file or directory with a timestamped suffix, preserving the source's permission bits. Raises `FileNotFoundError` if `strict=True` and source is missing.
+- `clean_directory(directory, *, strict=False)`. Recursively empty a directory in place. Raises `NotADirectoryError` if `strict=True` and target is not a directory.
+- `copy_file(src, dst, *, with_progress=False, transient=True, keep_backup=True, console=None, strict=False)`. Copy a file with optional progress and destination backup. Raises `IsADirectoryError` if `src` is a directory; raises `shutil.SameFileError` if `strict=True` and src equals dst.
+- `copy_directory(src, dst, *, with_progress=False, transient=True, keep_backup=True, console=None, strict=False)`. Recursively copy a directory, preserving directory permission bits. Requires Python 3.12+. Raises `shutil.SameFileError` or `ValueError` if `strict=True` and src/dst are the same or nested.
 - `directory_tree(directory, *, show_hidden=False)`. Build a `rich.tree.Tree` view of a directory.
 - `find_files(path, globs=None, *, ignore_dotfiles=False)`. List files in a directory matching globs. Duplicate matches across overlapping globs are deduped.
 - `find_subdirectories(directory, depth=1, filter_regex="", *, ignore_dotfiles=False, leaf_dirs_only=False)`. Search subdirectories with depth and regex filtering. `depth` must be >= 1.
-- `find_user_home_dir(username=None)`. Resolve a user's home directory, honoring `SUDO_USER` when running under sudo.
+- `find_user_home_dir(username=None, *, strict=False)`. Resolve a user's home directory, honoring `SUDO_USER` when running under sudo. Raises `KeyError` if `strict=True` and user is unknown.

--- a/docs/fs.md
+++ b/docs/fs.md
@@ -33,6 +33,8 @@ copy_file(src, dst, keep_backup=False)
 
 `with_progress=True` shows a Rich progress bar; `transient=True` (the default) clears the bar after the copy completes.
 
+For `copy_directory(..., with_progress=True)`, the bar shows the total bytes across all files plus a recycled per-file subtask. When `keep_backup=True` and the destination already exists, you'll see two sequential phases: a Backup phase (snapshotting the existing destination) that dismisses on completion, then a Copy phase. Each phase has its own progress bar.
+
 Pass `console=` to route the progress bar through your own Rich `Console` instead of Rich's global default. This is useful when you want the bar to share a console with `pretty_print.console()`:
 
 ```python
@@ -43,7 +45,10 @@ copy_file(src, dst, with_progress=True, console=console())
 ```
 
 > [!NOTE]
-> `copy_directory` requires Python 3.12+ because it uses `Path.walk()`. Calling it on an older interpreter raises `ValueError`.
+> Both `copy_directory` and `backup_path` (when given a directory) require Python 3.12+ because they use `Path.walk()`. Calling either on an older interpreter raises `ValueError`. File backups (`backup_path` on a single file) work on Python 3.10+.
+
+> [!NOTE]
+> `copy_directory` and the directory variant of `backup_path` both follow symlinks: a symlink to a directory inside the source tree is materialized as a real directory in the destination, with the symlink target's contents copied recursively. This matches `shutil.copytree(symlinks=False)` (the default).
 
 > [!NOTE]
 > By default, same-source-and-destination and parent/child copy attempts return the source path and log a warning. Pass `strict=True` to raise `shutil.SameFileError` or `ValueError` instead.
@@ -71,7 +76,7 @@ backup_path(original, backup_suffix=".pre-migration.bak")
 By default `backup_path` returns `None` when the source doesn't exist. Pass `strict=True` to raise `FileNotFoundError` instead.
 
 > [!NOTE]
-> File backups preserve the source's permission bits (mode). Directory backups inherit mode and timestamps via `shutil.copytree`.
+> File backups preserve the source's permission bits (mode); file timestamps are not preserved. Directory backups walk the tree with `Path.walk(follow_symlinks=True)`, mirror directory mode and timestamps via `shutil.copystat`, and follow symlinks (including symlinked subdirectories) so the backup contains resolved contents. This matches `shutil.copytree(src, target)` defaults.
 
 ## Cleaning a directory
 

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -119,6 +119,9 @@ class _Copier:
             msg = (
                 f"source file `{src}` and destination file `{dst}` are the same file. Did not copy."
             )
+            if self.strict:
+                logger.error(msg)
+                raise shutil.SameFileError(msg) from None
             logger.warning(msg)
             return src
 
@@ -146,7 +149,7 @@ class _Copier:
 
         return dst
 
-    def copy_directory(self, src: Path, dst: Path, *, keep_backup: bool = True) -> Path:
+    def copy_directory(self, src: Path, dst: Path, *, keep_backup: bool = True) -> Path:  # noqa: C901
         """Copy a directory tree to a new destination using this Copier's shared configuration.
 
         Validates Python 3.12+, src exists and is a directory, src and dst are not
@@ -169,11 +172,17 @@ class _Copier:
         # Prevent copying a directory to itself or into itself to avoid infinite recursion
         if src == dst:
             msg = f"source directory `{src}` and destination directory `{dst}` are the same directory. Did not copy."
+            if self.strict:
+                logger.error(msg)
+                raise shutil.SameFileError(msg) from None
             logger.warning(msg)
             return src
 
         if src in dst.parents or dst in src.parents:
             msg = f"source directory `{src}` and destination directory `{dst}` have parent/child relationship. Did not copy."
+            if self.strict:
+                logger.error(msg)
+                raise ValueError(msg) from None
             logger.warning(msg)
             return src
 
@@ -245,17 +254,15 @@ class _Copier:
                     _do_copy_file(src_file, new_parent / name, progress_bar=progress, task=inner)
                     progress.update(outer, advance=size)
 
-    def backup(
-        self, src: Path, backup_suffix: str = "", *, raise_on_missing: bool = False
-    ) -> Path | None:
+    def backup(self, src: Path, backup_suffix: str = "") -> Path | None:
         """Create a backup copy of `src` by appending `backup_suffix` to its name.
 
         If `backup_suffix` is empty, generates a timestamped suffix. Skips silently when
-        `src` does not exist (or raises `FileNotFoundError` if `raise_on_missing`).
+        `src` does not exist (or raises `FileNotFoundError` if `self.strict` is True).
         """
         if not src.exists():
             msg = f"skip backup: does not exist `{src}`"
-            if raise_on_missing:
+            if self.strict:
                 logger.error(msg)
                 raise FileNotFoundError(msg) from None
             logger.warning(msg)
@@ -301,40 +308,53 @@ def backup_path(
     src: Path,
     backup_suffix: str = "",
     *,
-    raise_on_missing: bool = False,
     with_progress: bool = False,
     transient: bool = True,
     console: Console | None = None,
+    strict: bool = False,
 ) -> Path | None:
-    """Create a backup copy of a file/directory by appending a suffix to the original name. If no suffix is provided, generate one using a timestamp. Skip if the source path doesn't exist.
+    """Create a backup copy of a file/directory by appending a suffix to the original name.
+
+    If no suffix is provided, generate one using a timestamp. By default, returns
+    None when the source path does not exist; pass `strict=True` to raise
+    `FileNotFoundError` instead.
 
     Args:
         src (Path): Path to the file or directory to back up.
         backup_suffix (str, optional): Custom suffix to append to the backup name. Defaults to a timestamp-based suffix.
-        raise_on_missing (bool, optional): Raise if the source path does not exist. Defaults to False.
         with_progress (bool, optional): Show a progress bar during file copies. Defaults to False.
         transient (bool, optional): Remove the progress bar after completion. Defaults to True.
-        console (Console | None, optional): Rich `Console` to render the progress bar through. Defaults to None (Rich's default global console).
+        console (Console | None, optional): Rich `Console` to render the progress bar through. Defaults to None.
+        strict (bool, optional): Raise on silent failure modes (missing source). Defaults to False.
 
     Returns:
-        Path | None: Path to the created backup file/directory, or None if the source does not exist and `raise_on_missing` is False.
+        Path | None: Path to the created backup file/directory, or None if the source does not exist and `strict` is False.
 
     Raises:
-        FileNotFoundError: If the source path does not exist and `raise_on_missing` is True.
+        FileNotFoundError: If the source path does not exist and `strict` is True.
     """
-    return _Copier(with_progress=with_progress, transient=transient, console=console).backup(
-        src, backup_suffix, raise_on_missing=raise_on_missing
-    )
+    return _Copier(
+        with_progress=with_progress, transient=transient, console=console, strict=strict
+    ).backup(src, backup_suffix)
 
 
-def clean_directory(directory: Path) -> None:
-    """Recursively cleans up the contents of a directory, deleting all files and subdirectories without deleting the directory itself.
+def clean_directory(directory: Path, *, strict: bool = False) -> None:
+    """Recursively clean up the contents of a directory.
+
+    Delete all files and subdirectories without deleting the directory itself.
 
     Args:
         directory (Path): The directory to clean up.
+        strict (bool, optional): Raise NotADirectoryError if `directory` is not an existing directory. Defaults to False.
+
+    Raises:
+        NotADirectoryError: If `directory` is not an existing directory and `strict` is True.
     """
     if not directory.is_dir():
         msg = f"{directory} is not a directory. Did not clean up."
+        if strict:
+            logger.error(msg)
+            raise NotADirectoryError(msg) from None
         logger.warning(msg)
         return
 
@@ -345,7 +365,7 @@ def clean_directory(directory: Path) -> None:
             shutil.rmtree(child)
 
 
-def copy_file(
+def copy_file(  # noqa: PLR0913
     src: Path,
     dst: Path,
     *,
@@ -353,6 +373,7 @@ def copy_file(
     transient: bool = True,
     keep_backup: bool = True,
     console: Console | None = None,
+    strict: bool = False,
 ) -> Path:
     """Copy a file to a destination with optional progress tracking.
 
@@ -364,22 +385,24 @@ def copy_file(
         with_progress (bool, optional): Show a progress bar during copy. Defaults to False.
         transient (bool, optional): Remove the progress bar after completion. Defaults to True.
         keep_backup (bool, optional): Keep a backup of the destination file if it already exists. Defaults to True.
-        console (Console | None, optional): Rich `Console` to render the progress bar through. Defaults to None (Rich's default global console).
+        console (Console | None, optional): Rich `Console` to render the progress bar through. Defaults to None.
+        strict (bool, optional): Raise on silent failure modes (src equals dst). Defaults to False.
 
     Returns:
-        Path: Path to the destination file after copy completion
+        Path: Path to the destination file after copy completion.
 
     Raises:
-        FileNotFoundError: If the source path does not exist
-        IsADirectoryError: If the source path is a directory
-        OSError: If the source path exists but is not a regular file
+        FileNotFoundError: If the source path does not exist.
+        IsADirectoryError: If the source path is a directory.
+        OSError: If the source path exists but is not a regular file.
+        shutil.SameFileError: If src and dst resolve to the same file and `strict` is True.
     """
-    return _Copier(with_progress=with_progress, transient=transient, console=console).copy_file(
-        src, dst, keep_backup=keep_backup
-    )
+    return _Copier(
+        with_progress=with_progress, transient=transient, console=console, strict=strict
+    ).copy_file(src, dst, keep_backup=keep_backup)
 
 
-def copy_directory(
+def copy_directory(  # noqa: PLR0913
     src: Path,
     dst: Path,
     *,
@@ -387,6 +410,7 @@ def copy_directory(
     transient: bool = True,
     keep_backup: bool = True,
     console: Console | None = None,
+    strict: bool = False,
 ) -> Path:
     """Copy a directory and its contents to a new destination path.
 
@@ -399,16 +423,18 @@ def copy_directory(
         transient (bool, optional): Clear progress bar after completion. Defaults to True.
         keep_backup (bool, optional): Keep a backup of the destination directory if it already exists. Defaults to True.
         console (Console | None, optional): Rich `Console` to render the progress bar through. Defaults to None.
+        strict (bool, optional): Raise on silent failure modes (src equals dst, or src/dst nested). Defaults to False.
 
     Returns:
         Path: Path to the destination directory.
 
     Raises:
         FileNotFoundError: If source directory does not exist or is not a directory.
-        ValueError: If Python version is less than 3.12.
+        ValueError: If Python version is less than 3.12, or if src/dst have a parent/child relationship and `strict` is True.
+        shutil.SameFileError: If src and dst are the same directory and `strict` is True.
     """
     return _Copier(
-        with_progress=with_progress, transient=transient, console=console
+        with_progress=with_progress, transient=transient, console=console, strict=strict
     ).copy_directory(src, dst, keep_backup=keep_backup)
 
 
@@ -578,20 +604,26 @@ def find_files(
     return sorted(results)
 
 
-def find_user_home_dir(username: str | None = None) -> Path | None:
+def find_user_home_dir(username: str | None = None, *, strict: bool = False) -> Path | None:
     """Locate and return the home directory path for a given or current user.
 
     If no username is provided, fall back to the `SUDO_USER` environment variable so
     scripts running under sudo resolve the invoking user's home rather than `/root`.
     On POSIX systems, lookups go through the standard library `pwd` module
     (`pwd.getpwnam(username).pw_dir`). On platforms without `pwd` (e.g. Windows),
-    return `None` and log a warning.
+    return `None` and log a warning. The `pwd` unavailability path always returns None
+    regardless of `strict`, since it represents a platform capability rather than a
+    runtime error.
 
     Args:
         username (str | None, optional): Username to find home directory for. If None, use SUDO_USER or the current user. Defaults to None.
+        strict (bool, optional): Raise KeyError on unknown user. Defaults to False.
 
     Returns:
-        Path | None: Home directory path for the specified user, or None if the user is not found or the platform does not provide `pwd`.
+        Path | None: Home directory path for the specified user, or None if the user is not found, or the platform does not provide `pwd`, or both.
+
+    Raises:
+        KeyError: If `username` is not a known user and `strict` is True.
     """
     if username is None:
         sudo_user = os.getenv("SUDO_USER")
@@ -608,5 +640,9 @@ def find_user_home_dir(username: str | None = None) -> Path | None:
     try:
         return Path(pwd.getpwnam(username).pw_dir)
     except KeyError:
-        logger.debug("pwd lookup failed for `%s`", username)
+        msg = f"pwd lookup failed for `{username}`"
+        if strict:
+            logger.error(msg)  # noqa: TRY400
+            raise
+        logger.debug(msg)
         return None

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -69,9 +69,10 @@ def _sum_bytes(root: Path) -> tuple[int, int]:
     """
     total = 0
     count = 0
-    for current_root, _, files in root.walk():
+    for current_root, _, files in os.walk(root):
+        base = Path(current_root)
         for name in files:
-            total += (current_root / name).stat().st_size
+            total += (base / name).stat().st_size
             count += 1
     return total, count
 
@@ -97,7 +98,7 @@ class _Copier:
         """Stub. Filled in by Tasks 5 and 6."""
         raise NotImplementedError
 
-    def backup(self, src: Path, suffix: str = "") -> Path | None:
+    def backup(self, src: Path, backup_suffix: str = "") -> Path | None:
         """Stub. Filled in by Tasks 2 and 3."""
         raise NotImplementedError
 

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -119,6 +119,8 @@ class _Copier:
 
         target = src.with_name(src.name + backup_suffix)
 
+        # Clear the target if anything is already there. This isn't atomic across processes,
+        # but the timestamped default suffix makes a real collision very rare.
         if target.is_symlink() or target.is_file():
             logger.debug("unlink %s", target)
             target.unlink()

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -146,8 +146,50 @@ class _Copier:
         return dst
 
     def copy_directory(self, src: Path, dst: Path, *, keep_backup: bool = True) -> Path:
-        """Stub. Filled in by Tasks 5 and 6."""
-        raise NotImplementedError
+        """Copy a directory tree to a new destination using this Copier's shared configuration.
+
+        Validates Python 3.12+, src exists and is a directory, src and dst are not
+        the same and not in a parent/child relationship. If dst exists and
+        keep_backup is True, snapshots dst via self.backup() first.
+        """
+        if not check_python_version(3, 12):
+            msg = "Copy file requires a minimum of Python version 3.12"
+            logger.error(msg)
+            raise ValueError(msg) from None
+
+        src = src.expanduser().resolve()
+        dst = dst.expanduser().resolve()
+
+        if not src.exists() or not src.is_dir():
+            msg = f"source directory `{src}` does not exist or is not a directory. Did not copy."
+            logger.error(msg)
+            raise FileNotFoundError(msg) from None
+
+        # Prevent copying a directory to itself or into itself to avoid infinite recursion
+        if src == dst:
+            msg = f"source directory `{src}` and destination directory `{dst}` are the same directory. Did not copy."
+            logger.warning(msg)
+            return src
+
+        if src in dst.parents or dst in src.parents:
+            msg = f"source directory `{src}` and destination directory `{dst}` have parent/child relationship. Did not copy."
+            logger.warning(msg)
+            return src
+
+        if dst.exists() and keep_backup:
+            logger.debug("backup %s", dst)
+            self.backup(dst)
+
+        if dst.is_symlink():
+            logger.debug("unlink %s", dst)
+            dst.unlink()
+        elif dst.is_dir():
+            logger.debug("rmtree %s", dst)
+            shutil.rmtree(dst)
+
+        logger.debug("walk %s", src)
+        self._copy_tree_no_progress(src, dst)
+        return dst
 
     def _copy_tree_no_progress(self, src: Path, dst: Path) -> None:
         """Copy a directory tree from src to dst using chunked file I/O.
@@ -310,75 +352,26 @@ def copy_directory(
 ) -> Path:
     """Copy a directory and its contents to a new destination path.
 
-    Recursively copy all files and subdirectories from the source directory to the destination, preserving the directory structure. Display an optional progress bar for each file being copied.
+    Recursively copy all files and subdirectories from the source directory to the destination, preserving the directory structure. Display an optional progress bar for the copy.
 
     Args:
-        src (Path): Source directory to copy from
-        dst (Path): Destination directory to copy to
+        src (Path): Source directory to copy from.
+        dst (Path): Destination directory to copy to.
         with_progress (bool, optional): Show progress bar while copying files. Defaults to False.
         transient (bool, optional): Clear progress bar after completion. Defaults to True.
         keep_backup (bool, optional): Keep a backup of the destination directory if it already exists. Defaults to True.
-        console (Console | None, optional): Rich `Console` to render the progress bar through. Defaults to None (Rich's default global console).
+        console (Console | None, optional): Rich `Console` to render the progress bar through. Defaults to None.
 
     Returns:
-        Path: Path to the destination directory
+        Path: Path to the destination directory.
 
     Raises:
-        FileNotFoundError: If source directory does not exist or is not a directory
-        ValueError: If Python version is less than 3.12
+        FileNotFoundError: If source directory does not exist or is not a directory.
+        ValueError: If Python version is less than 3.12.
     """
-    if not check_python_version(3, 12):
-        msg = "Copy file requires a minimum of Python version 3.12"
-        logger.error(msg)
-        raise ValueError(msg) from None
-
-    src = src.expanduser().resolve()
-    dst = dst.expanduser().resolve()
-
-    if not src.exists() or not src.is_dir():
-        msg = f"source directory `{src}` does not exist or is not a directory. Did not copy."
-        logger.error(msg)
-        raise FileNotFoundError(msg) from None
-
-    # Prevent copying a directory to itself or into itself to avoid infinite recursion
-    if src == dst:
-        msg = f"source directory `{src}` and destination directory `{dst}` are the same directory. Did not copy."
-        logger.warning(msg)
-        return src
-
-    if src in dst.parents or dst in src.parents:
-        msg = f"source directory `{src}` and destination directory `{dst}` have parent/child relationship. Did not copy."
-        logger.warning(msg)
-        return src
-
-    if dst.exists() and keep_backup:
-        logger.debug("backup %s", dst)
-        backup_path(dst, with_progress=with_progress, transient=transient, console=console)
-
-    if dst.is_symlink():
-        logger.debug("unlink %s", dst)
-        dst.unlink()
-    elif dst.is_dir():
-        logger.debug("rmtree %s", dst)
-        shutil.rmtree(dst)
-
-    logger.debug("walk %s", src)
-    for root, _, files in src.walk():
-        rel = root.relative_to(src)
-        new_parent = dst / rel
-        new_parent.mkdir(parents=True, exist_ok=True)
-        shutil.copystat(root, new_parent)
-
-        for file in files:
-            copy_file(
-                src=root / file,
-                dst=new_parent / file,
-                with_progress=with_progress,
-                transient=transient,
-                console=console,
-            )
-
-    return dst
+    return _Copier(
+        with_progress=with_progress, transient=transient, console=console
+    ).copy_directory(src, dst, keep_backup=keep_backup)
 
 
 def directory_tree(directory: Path, *, show_hidden: bool = False) -> Tree:

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 from rich.console import Console
@@ -57,6 +58,48 @@ def _do_copy_file(
         raise RuntimeError(msg) from None
 
     shutil.copymode(src, dst)
+
+
+def _sum_bytes(root: Path) -> tuple[int, int]:
+    """Return (total_bytes, file_count) for every file under root.
+
+    Used by `_Copier` to drive a determinate progress bar when `with_progress=True`.
+    The extra `os.stat` per file is the cost of an accurate ETA and percentage; callers
+    that pass `with_progress=False` never trigger this walk.
+    """
+    total = 0
+    count = 0
+    for current_root, _, files in root.walk():
+        for name in files:
+            total += (current_root / name).stat().st_size
+            count += 1
+    return total, count
+
+
+@dataclass(frozen=True, kw_only=True)
+class _Copier:
+    """Internal helper holding shared copy/backup configuration.
+
+    Public functions (`copy_file`, `copy_directory`, `backup_path`) build a one-shot
+    instance and delegate. Not exported.
+    """
+
+    with_progress: bool = False
+    transient: bool = True
+    console: Console | None = None
+    strict: bool = False
+
+    def copy_file(self, src: Path, dst: Path, *, keep_backup: bool = True) -> Path:
+        """Stub. Filled in by Task 4."""
+        raise NotImplementedError
+
+    def copy_directory(self, src: Path, dst: Path, *, keep_backup: bool = True) -> Path:
+        """Stub. Filled in by Tasks 5 and 6."""
+        raise NotImplementedError
+
+    def backup(self, src: Path, suffix: str = "") -> Path | None:
+        """Stub. Filled in by Tasks 2 and 3."""
+        raise NotImplementedError
 
 
 def backup_path(

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -157,14 +157,15 @@ class _Copier:
         keep_backup is True, snapshots dst via self.backup() first.
         """
         if not check_python_version(3, 12):
-            msg = "Copy file requires a minimum of Python version 3.12"
+            msg = "Copy directory requires a minimum of Python version 3.12"
             logger.error(msg)
             raise ValueError(msg) from None
 
         src = src.expanduser().resolve()
         dst = dst.expanduser().resolve()
 
-        if not src.exists() or not src.is_dir():
+        # Path.is_dir() returns False for missing paths, so it covers the existence check too.
+        if not src.is_dir():
             msg = f"source directory `{src}` does not exist or is not a directory. Did not copy."
             logger.error(msg)
             raise FileNotFoundError(msg) from None
@@ -238,7 +239,7 @@ class _Copier:
 
         with Progress(transient=self.transient, console=self.console) as progress:
             outer = progress.add_task(f"{label} {src.name}", total=total_bytes or None)
-            inner = progress.add_task("", total=1, visible=False)
+            inner = progress.add_task("", total=None, visible=False)
 
             for current_root, _, files in src.walk(follow_symlinks=True):
                 rel = current_root.relative_to(src)

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -98,6 +98,23 @@ class _Copier:
         """Stub. Filled in by Tasks 5 and 6."""
         raise NotImplementedError
 
+    def _copy_tree_no_progress(self, src: Path, dst: Path) -> None:
+        """Copy a directory tree from src to dst using chunked file I/O.
+
+        Mirrors `shutil.copytree(src, dst)` (no kwargs) semantics: follows
+        symlinks, preserves dir + file mode, creates empty subdirs, propagates
+        errors. Used when no progress bar is wanted.
+        """
+        dst.mkdir(parents=True, exist_ok=True)
+        shutil.copystat(src, dst)
+        for current_root, _, files in src.walk():
+            rel = current_root.relative_to(src)
+            new_parent = dst / rel
+            new_parent.mkdir(parents=True, exist_ok=True)
+            shutil.copystat(current_root, new_parent)
+            for name in files:
+                _do_copy_file(current_root / name, new_parent / name)
+
     def backup(
         self, src: Path, backup_suffix: str = "", *, raise_on_missing: bool = False
     ) -> Path | None:
@@ -129,8 +146,8 @@ class _Copier:
             shutil.rmtree(target)
 
         if src.is_dir():
-            logger.debug("copytree %s %s", src, target)
-            shutil.copytree(src, target)
+            logger.debug("copy_tree %s %s", src, target)
+            self._copy_tree_no_progress(src, target)
         elif self.with_progress:
             with Progress(transient=self.transient, console=self.console) as progress_bar:
                 copy_task = progress_bar.add_task(f"Backup {src.name}", total=src.stat().st_size)

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -101,13 +101,15 @@ class _Copier:
     def _copy_tree_no_progress(self, src: Path, dst: Path) -> None:
         """Copy a directory tree from src to dst using chunked file I/O.
 
-        Mirrors `shutil.copytree(src, dst)` (no kwargs) semantics: follows
-        symlinks, preserves dir + file mode, creates empty subdirs, propagates
-        errors. Used when no progress bar is wanted.
+        Approximates `shutil.copytree(src, dst)` (no kwargs) semantics: follows
+        symlinks (including to directories), preserves directory mode and
+        timestamps via `shutil.copystat`, preserves file mode via
+        `shutil.copymode`, creates empty subdirs, propagates errors. File
+        timestamps (atime, mtime) are intentionally not preserved because the
+        write itself bumps mtime; this matches the existing `copy_directory`
+        behavior.
         """
-        dst.mkdir(parents=True, exist_ok=True)
-        shutil.copystat(src, dst)
-        for current_root, _, files in src.walk():
+        for current_root, _, files in src.walk(follow_symlinks=True):
             rel = current_root.relative_to(src)
             new_parent = dst / rel
             new_parent.mkdir(parents=True, exist_ok=True)
@@ -146,6 +148,10 @@ class _Copier:
             shutil.rmtree(target)
 
         if src.is_dir():
+            if not check_python_version(3, 12):
+                msg = "Backup of a directory requires a minimum of Python version 3.12"
+                logger.error(msg)
+                raise ValueError(msg) from None
             logger.debug("copy_tree %s %s", src, target)
             self._copy_tree_no_progress(src, target)
         elif self.with_progress:

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -138,14 +138,7 @@ class _Copier:
             logger.debug("rmtree %s", dst)
             shutil.rmtree(dst)
 
-        if self.with_progress:
-            with Progress(transient=self.transient, console=self.console) as progress_bar:
-                copy_task = progress_bar.add_task(f"Copy {src.name}", total=src.stat().st_size)
-                _do_copy_file(src, dst, progress_bar=progress_bar, task=copy_task)
-                logger.debug("copyfile %s %s", src, dst)
-        else:
-            _do_copy_file(src, dst)
-            logger.debug("copyfile %s %s", src, dst)
+        self._copy_single_file(src, dst, label="Copy")
 
         return dst
 
@@ -255,6 +248,20 @@ class _Copier:
                     _do_copy_file(src_file, new_parent / name, progress_bar=progress, task=inner)
                     progress.update(outer, advance=size)
 
+    def _copy_single_file(self, src: Path, dst: Path, label: str) -> None:
+        """Copy a single file with optional Progress, using this Copier's config.
+
+        Shared by `copy_file` and `backup`'s file branch so both call sites
+        agree on Progress setup, label format, and debug logging.
+        """
+        if self.with_progress:
+            with Progress(transient=self.transient, console=self.console) as progress_bar:
+                copy_task = progress_bar.add_task(f"{label} {src.name}", total=src.stat().st_size)
+                _do_copy_file(src, dst, progress_bar=progress_bar, task=copy_task)
+        else:
+            _do_copy_file(src, dst)
+        logger.debug("copyfile %s %s", src, dst)
+
     def backup(self, src: Path, backup_suffix: str = "") -> Path | None:
         """Create a backup copy of `src` by appending `backup_suffix` to its name.
 
@@ -293,14 +300,8 @@ class _Copier:
                 self._copy_tree_with_progress(src, target, label="Backup")
             else:
                 self._copy_tree_no_progress(src, target)
-        elif self.with_progress:
-            with Progress(transient=self.transient, console=self.console) as progress_bar:
-                copy_task = progress_bar.add_task(f"Backup {src.name}", total=src.stat().st_size)
-                logger.debug("copyfile %s %s", src, target)
-                _do_copy_file(src, target, progress_bar=progress_bar, task=copy_task)
         else:
-            logger.debug("copyfile %s %s", src, target)
-            _do_copy_file(src, target)
+            self._copy_single_file(src, target, label="Backup")
 
         return target
 

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -65,11 +65,12 @@ def _sum_bytes(root: Path) -> tuple[int, int]:
 
     Used by `_Copier` to drive a determinate progress bar when `with_progress=True`.
     The extra `os.stat` per file is the cost of an accurate ETA and percentage; callers
-    that pass `with_progress=False` never trigger this walk.
+    that pass `with_progress=False` never trigger this walk. Symlinked directories are
+    followed so the count matches `_copy_tree_with_progress`'s walk.
     """
     total = 0
     count = 0
-    for current_root, _, files in os.walk(root):
+    for current_root, _, files in os.walk(root, followlinks=True):
         base = Path(current_root)
         for name in files:
             total += (base / name).stat().st_size
@@ -227,7 +228,7 @@ class _Copier:
         total_bytes, _ = _sum_bytes(src)
 
         with Progress(transient=self.transient, console=self.console) as progress:
-            outer = progress.add_task(f"{label} {src.name}", total=total_bytes)
+            outer = progress.add_task(f"{label} {src.name}", total=total_bytes or None)
             inner = progress.add_task("", total=1, visible=False)
 
             for current_root, _, files in src.walk(follow_symlinks=True):
@@ -238,7 +239,9 @@ class _Copier:
                 for name in files:
                     src_file = current_root / name
                     size = src_file.stat().st_size
-                    progress.reset(inner, description=f"  └ {rel / name}", total=size, visible=True)
+                    progress.reset(
+                        inner, description=f"  └ {rel / name}", total=size or None, visible=True
+                    )
                     _do_copy_file(src_file, new_parent / name, progress_bar=progress, task=inner)
                     progress.update(outer, advance=size)
 

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -188,7 +188,10 @@ class _Copier:
             shutil.rmtree(dst)
 
         logger.debug("walk %s", src)
-        self._copy_tree_no_progress(src, dst)
+        if self.with_progress:
+            self._copy_tree_with_progress(src, dst, label="Copy")
+        else:
+            self._copy_tree_no_progress(src, dst)
         return dst
 
     def _copy_tree_no_progress(self, src: Path, dst: Path) -> None:
@@ -209,6 +212,35 @@ class _Copier:
             shutil.copystat(current_root, new_parent)
             for name in files:
                 _do_copy_file(current_root / name, new_parent / name)
+
+    def _copy_tree_with_progress(self, src: Path, dst: Path, label: str) -> None:
+        """Copy a directory tree with a unified Progress bar.
+
+        Pre-walks `src` once to compute total bytes, then drives a single
+        `Progress` containing one outer total-bytes task and one recycled
+        per-file subtask. `label` is used as the description prefix
+        (e.g. "Copy" or "Backup"). Mirrors `_copy_tree_no_progress`'s
+        semantics: follows symlinks, preserves directory mode/timestamps via
+        `shutil.copystat`, preserves file mode via `shutil.copymode`, and
+        intentionally does not preserve file mtime (the write bumps it).
+        """
+        total_bytes, _ = _sum_bytes(src)
+
+        with Progress(transient=self.transient, console=self.console) as progress:
+            outer = progress.add_task(f"{label} {src.name}", total=total_bytes)
+            inner = progress.add_task("", total=1, visible=False)
+
+            for current_root, _, files in src.walk(follow_symlinks=True):
+                rel = current_root.relative_to(src)
+                new_parent = dst / rel
+                new_parent.mkdir(parents=True, exist_ok=True)
+                shutil.copystat(current_root, new_parent)
+                for name in files:
+                    src_file = current_root / name
+                    size = src_file.stat().st_size
+                    progress.reset(inner, description=f"  └ {rel / name}", total=size, visible=True)
+                    _do_copy_file(src_file, new_parent / name, progress_bar=progress, task=inner)
+                    progress.update(outer, advance=size)
 
     def backup(
         self, src: Path, backup_suffix: str = "", *, raise_on_missing: bool = False
@@ -246,7 +278,10 @@ class _Copier:
                 logger.error(msg)
                 raise ValueError(msg) from None
             logger.debug("copy_tree %s %s", src, target)
-            self._copy_tree_no_progress(src, target)
+            if self.with_progress:
+                self._copy_tree_with_progress(src, target, label="Backup")
+            else:
+                self._copy_tree_no_progress(src, target)
         elif self.with_progress:
             with Progress(transient=self.transient, console=self.console) as progress_bar:
                 copy_task = progress_bar.add_task(f"Backup {src.name}", total=src.stat().st_size)

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -98,9 +98,47 @@ class _Copier:
         """Stub. Filled in by Tasks 5 and 6."""
         raise NotImplementedError
 
-    def backup(self, src: Path, backup_suffix: str = "") -> Path | None:
-        """Stub. Filled in by Tasks 2 and 3."""
-        raise NotImplementedError
+    def backup(
+        self, src: Path, backup_suffix: str = "", *, raise_on_missing: bool = False
+    ) -> Path | None:
+        """Create a backup copy of `src` by appending `backup_suffix` to its name.
+
+        If `backup_suffix` is empty, generates a timestamped suffix. Skips silently when
+        `src` does not exist (or raises `FileNotFoundError` if `raise_on_missing`).
+        """
+        if not src.exists():
+            msg = f"skip backup: does not exist `{src}`"
+            if raise_on_missing:
+                logger.error(msg)
+                raise FileNotFoundError(msg) from None
+            logger.warning(msg)
+            return None
+
+        if not backup_suffix:
+            backup_suffix = "." + new_timestamp_uid() + ".bak"
+
+        target = src.with_name(src.name + backup_suffix)
+
+        if target.is_symlink() or target.is_file():
+            logger.debug("unlink %s", target)
+            target.unlink()
+        elif target.is_dir():
+            logger.debug("rmtree %s", target)
+            shutil.rmtree(target)
+
+        if src.is_dir():
+            logger.debug("copytree %s %s", src, target)
+            shutil.copytree(src, target)
+        elif self.with_progress:
+            with Progress(transient=self.transient, console=self.console) as progress_bar:
+                copy_task = progress_bar.add_task(f"Backup {src.name}", total=src.stat().st_size)
+                logger.debug("copyfile %s %s", src, target)
+                _do_copy_file(src, target, progress_bar=progress_bar, task=copy_task)
+        else:
+            logger.debug("copyfile %s %s", src, target)
+            _do_copy_file(src, target)
+
+        return target
 
 
 def backup_path(
@@ -128,41 +166,9 @@ def backup_path(
     Raises:
         FileNotFoundError: If the source path does not exist and `raise_on_missing` is True.
     """
-    if not src.exists():
-        msg = f"skip backup: does not exist `{src}`"
-        if raise_on_missing:
-            logger.error(msg)
-            raise FileNotFoundError(msg) from None
-        logger.warning(msg)
-        return None
-
-    if not backup_suffix:
-        backup_suffix = "." + new_timestamp_uid() + ".bak"
-
-    target = src.with_name(src.name + backup_suffix)
-
-    # Clear the target if anything is already there. This isn't atomic across processes,
-    # but the timestamped default suffix makes a real collision very rare.
-    if target.is_symlink() or target.is_file():
-        logger.debug("unlink %s", target)
-        target.unlink()
-    elif target.is_dir():
-        logger.debug("rmtree %s", target)
-        shutil.rmtree(target)
-
-    if src.is_dir():
-        logger.debug("copytree %s %s", src, target)
-        shutil.copytree(src, target)
-    elif with_progress:
-        with Progress(transient=transient, console=console) as progress_bar:
-            copy_task = progress_bar.add_task(f"Backup {src.name}", total=src.stat().st_size)
-            logger.debug("copyfile %s %s", src, target)
-            _do_copy_file(src, target, progress_bar=progress_bar, task=copy_task)
-    else:
-        logger.debug("copyfile %s %s", src, target)
-        _do_copy_file(src, target)
-
-    return target
+    return _Copier(with_progress=with_progress, transient=transient, console=console).backup(
+        src, backup_suffix, raise_on_missing=raise_on_missing
+    )
 
 
 def clean_directory(directory: Path) -> None:

--- a/src/nclutils/fs/filesystem.py
+++ b/src/nclutils/fs/filesystem.py
@@ -91,8 +91,59 @@ class _Copier:
     strict: bool = False
 
     def copy_file(self, src: Path, dst: Path, *, keep_backup: bool = True) -> Path:
-        """Stub. Filled in by Task 4."""
-        raise NotImplementedError
+        """Copy a file to a destination using this Copier's shared configuration.
+
+        Validates that src is a regular existing file. If dst exists and keep_backup
+        is True, snapshots dst via self.backup() before overwriting.
+        """
+        src = src.expanduser().resolve()
+        dst = dst.expanduser().resolve()
+
+        if not src.exists():
+            msg = f"source file `{src}` does not exist. Did not copy."
+            logger.error(msg)
+            raise FileNotFoundError(msg) from None
+
+        if src.is_dir():
+            msg = f"source `{src}` is a directory, not a file. Did not copy."
+            logger.error(msg)
+            raise IsADirectoryError(msg) from None
+
+        if not src.is_file():
+            msg = f"source `{src}` is not a regular file. Did not copy."
+            logger.error(msg)
+            raise OSError(msg) from None
+
+        if src == dst or (dst.exists() and src.samefile(dst)):
+            msg = (
+                f"source file `{src}` and destination file `{dst}` are the same file. Did not copy."
+            )
+            logger.warning(msg)
+            return src
+
+        if dst.exists() and keep_backup:
+            logger.debug("backup %s", dst)
+            self.backup(dst)
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+
+        if dst.is_symlink():
+            logger.debug("unlink %s", dst)
+            dst.unlink()
+        elif dst.is_dir():
+            logger.debug("rmtree %s", dst)
+            shutil.rmtree(dst)
+
+        if self.with_progress:
+            with Progress(transient=self.transient, console=self.console) as progress_bar:
+                copy_task = progress_bar.add_task(f"Copy {src.name}", total=src.stat().st_size)
+                _do_copy_file(src, dst, progress_bar=progress_bar, task=copy_task)
+                logger.debug("copyfile %s %s", src, dst)
+        else:
+            _do_copy_file(src, dst)
+            logger.debug("copyfile %s %s", src, dst)
+
+        return dst
 
     def copy_directory(self, src: Path, dst: Path, *, keep_backup: bool = True) -> Path:
         """Stub. Filled in by Tasks 5 and 6."""
@@ -243,52 +294,9 @@ def copy_file(
         IsADirectoryError: If the source path is a directory
         OSError: If the source path exists but is not a regular file
     """
-    src = src.expanduser().resolve()
-    dst = dst.expanduser().resolve()
-
-    if not src.exists():
-        msg = f"source file `{src}` does not exist. Did not copy."
-        logger.error(msg)
-        raise FileNotFoundError(msg) from None
-
-    if src.is_dir():
-        msg = f"source `{src}` is a directory, not a file. Did not copy."
-        logger.error(msg)
-        raise IsADirectoryError(msg) from None
-
-    if not src.is_file():
-        msg = f"source `{src}` is not a regular file. Did not copy."
-        logger.error(msg)
-        raise OSError(msg) from None
-
-    if src == dst or (dst.exists() and src.samefile(dst)):
-        msg = f"source file `{src}` and destination file `{dst}` are the same file. Did not copy."
-        logger.warning(msg)
-        return src
-
-    if dst.exists() and keep_backup:
-        logger.debug("backup %s", dst)
-        backup_path(dst, with_progress=with_progress, transient=transient, console=console)
-
-    dst.parent.mkdir(parents=True, exist_ok=True)
-
-    if dst.is_symlink():
-        logger.debug("unlink %s", dst)
-        dst.unlink()
-    elif dst.is_dir():
-        logger.debug("rmtree %s", dst)
-        shutil.rmtree(dst)
-
-    if with_progress:
-        with Progress(transient=transient, console=console) as progress_bar:
-            copy_task = progress_bar.add_task(f"Copy {src.name}", total=src.stat().st_size)
-            _do_copy_file(src, dst, progress_bar=progress_bar, task=copy_task)
-            logger.debug("copyfile %s %s", src, dst)
-    else:
-        _do_copy_file(src, dst)
-        logger.debug("copyfile %s %s", src, dst)
-
-    return dst
+    return _Copier(with_progress=with_progress, transient=transient, console=console).copy_file(
+        src, dst, keep_backup=keep_backup
+    )
 
 
 def copy_directory(

--- a/tests/filesystem/test_backup.py
+++ b/tests/filesystem/test_backup.py
@@ -8,6 +8,9 @@ import pytest
 from pytest_mock import MockerFixture
 
 from nclutils.fs import backup_path
+from nclutils.utils import check_python_version
+
+requires_py312 = pytest.mark.skipif(not check_python_version(3, 12), reason="Requires Python 3.12+")
 
 
 @pytest.fixture
@@ -94,6 +97,7 @@ def test_backup_multiple_backups_same_backup_suffix(
     assert len(list(backup3.parent.glob("*.bak"))) == 1
 
 
+@requires_py312
 def test_backup_directory(backup_test_path: tuple[Path, Path, Path]) -> None:
     """Verify backing up directories preserves structure and content."""
     # Given: A test directory
@@ -149,6 +153,7 @@ def test_backup_path_preserves_file_mode(tmp_path: Path) -> None:
     assert (backup.stat().st_mode & 0o777) == 0o755
 
 
+@requires_py312
 def test_backup_directory_overwrites_existing_file_at_target(tmp_path: Path) -> None:
     """Verify backup_path replaces an existing regular file at the backup target when source is a directory."""
     # Given: A source directory and a regular file already sitting at the backup target
@@ -167,6 +172,7 @@ def test_backup_directory_overwrites_existing_file_at_target(tmp_path: Path) -> 
     assert (backup / "inner.txt").read_text() == "payload"
 
 
+@requires_py312
 def test_backup_directory_preserves_empty_subdirs(tmp_path: Path) -> None:
     """Verify directory backup preserves empty subdirectories."""
     # Given: A directory tree with an empty subdirectory
@@ -184,6 +190,7 @@ def test_backup_directory_preserves_empty_subdirs(tmp_path: Path) -> None:
     assert (target / "file.txt").read_text() == "hi"
 
 
+@requires_py312
 def test_backup_directory_preserves_file_mode(tmp_path: Path) -> None:
     """Verify directory backup preserves file permission bits."""
     # Given: A file with unusual permissions inside a directory
@@ -201,6 +208,7 @@ def test_backup_directory_preserves_file_mode(tmp_path: Path) -> None:
     assert stat.S_IMODE((target / "secret.txt").stat().st_mode) == 0o600
 
 
+@requires_py312
 def test_backup_directory_preserves_directory_mode(tmp_path: Path) -> None:
     """Verify directory backup preserves directory permission bits."""
     # Given: A subdirectory with unusual permissions
@@ -218,6 +226,7 @@ def test_backup_directory_preserves_directory_mode(tmp_path: Path) -> None:
     assert stat.S_IMODE((target / "private").stat().st_mode) == 0o700
 
 
+@requires_py312
 def test_backup_directory_follows_symlink_to_file(tmp_path: Path) -> None:
     """Verify directory backup follows symlinks (resolves to target contents)."""
     # Given: A directory containing a symlink to a file outside the tree
@@ -237,6 +246,7 @@ def test_backup_directory_follows_symlink_to_file(tmp_path: Path) -> None:
     assert (target / "link.txt").read_text() == "content"
 
 
+@requires_py312
 def test_backup_directory_follows_symlink_to_directory(tmp_path: Path) -> None:
     """Verify directory backup descends into symlinks pointing to directories."""
     # Given: A directory with a symlink to another directory containing a file
@@ -276,6 +286,7 @@ def test_backup_directory_raises_on_old_python(tmp_path: Path, mocker: MockerFix
         backup_path(src, backup_suffix=".bak")
 
 
+@requires_py312
 def test_backup_directory_matches_shutil_copytree_output(tmp_path: Path) -> None:
     """Verify the chunked walk produces a tree functionally identical to shutil.copytree."""
     # Given: A non-trivial directory tree

--- a/tests/filesystem/test_backup.py
+++ b/tests/filesystem/test_backup.py
@@ -239,6 +239,45 @@ def test_backup_directory_follows_symlink_to_file(tmp_path: Path) -> None:
     assert (target / "link.txt").read_text() == "content"
 
 
+def test_backup_directory_follows_symlink_to_directory(tmp_path: Path) -> None:
+    """Verify directory backup descends into symlinks pointing to directories."""
+    # Given: A directory with a symlink to another directory containing a file
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    (real_dir / "deep.txt").write_text("deep content")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "link_to_dir").symlink_to(real_dir)
+
+    # When: Backing up
+    target = backup_path(src, backup_suffix=".bak")
+
+    # Then: The link is materialized as a real directory containing the symlink target's contents
+    assert target is not None
+    backed_up = target / "link_to_dir"
+    assert backed_up.exists()
+    assert backed_up.is_dir()
+    assert not backed_up.is_symlink()
+    assert (backed_up / "deep.txt").read_text() == "deep content"
+
+
+def test_backup_directory_raises_on_old_python(tmp_path: Path, mocker) -> None:
+    """Verify backup_path raises ValueError when called on a directory under Python < 3.12."""
+    # Given: A directory and a mocked check_python_version returning False
+    src = tmp_path / "src"
+    src.mkdir()
+    mocker.patch(
+        "nclutils.fs.filesystem.check_python_version",
+        autospec=True,
+        return_value=False,
+    )
+
+    # When/Then: Backing up a directory raises ValueError
+    with pytest.raises(ValueError, match=r"Python version 3\.12"):
+        backup_path(src, backup_suffix=".bak")
+
+
 def test_backup_directory_matches_shutil_copytree_output(tmp_path: Path) -> None:
     """Verify the chunked walk produces a tree functionally identical to shutil.copytree."""
     # Given: A non-trivial directory tree

--- a/tests/filesystem/test_backup.py
+++ b/tests/filesystem/test_backup.py
@@ -5,6 +5,7 @@ import stat
 from pathlib import Path
 
 import pytest
+from pytest_mock import MockerFixture
 
 from nclutils.fs import backup_path
 
@@ -259,7 +260,7 @@ def test_backup_directory_follows_symlink_to_directory(tmp_path: Path) -> None:
     assert (backed_up / "deep.txt").read_text() == "deep content"
 
 
-def test_backup_directory_raises_on_old_python(tmp_path: Path, mocker) -> None:
+def test_backup_directory_raises_on_old_python(tmp_path: Path, mocker: MockerFixture) -> None:
     """Verify backup_path raises ValueError when called on a directory under Python < 3.12."""
     # Given: A directory and a mocked check_python_version returning False
     src = tmp_path / "src"

--- a/tests/filesystem/test_backup.py
+++ b/tests/filesystem/test_backup.py
@@ -1,5 +1,7 @@
 """Test the backup function."""
 
+import shutil
+import stat
 from pathlib import Path
 
 import pytest
@@ -165,3 +167,101 @@ def test_backup_directory_overwrites_existing_file_at_target(tmp_path: Path) -> 
     assert backup == target
     assert backup.is_dir()
     assert (backup / "inner.txt").read_text() == "payload"
+
+
+def test_backup_directory_preserves_empty_subdirs(tmp_path: Path) -> None:
+    """Verify directory backup preserves empty subdirectories."""
+    # Given: A directory tree with an empty subdirectory
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "empty").mkdir()
+    (src / "file.txt").write_text("hi")
+
+    # When: Backing up
+    target = backup_path(src, backup_suffix=".bak")
+
+    # Then: Empty subdirectory exists in the backup
+    assert target is not None
+    assert (target / "empty").is_dir()
+    assert (target / "file.txt").read_text() == "hi"
+
+
+def test_backup_directory_preserves_file_mode(tmp_path: Path) -> None:
+    """Verify directory backup preserves file permission bits."""
+    # Given: A file with unusual permissions inside a directory
+    src = tmp_path / "src"
+    src.mkdir()
+    f = src / "secret.txt"
+    f.write_text("x")
+    f.chmod(0o600)
+
+    # When: Backing up
+    target = backup_path(src, backup_suffix=".bak")
+
+    # Then: The file in the backup has the same permission bits
+    assert target is not None
+    assert stat.S_IMODE((target / "secret.txt").stat().st_mode) == 0o600
+
+
+def test_backup_directory_preserves_directory_mode(tmp_path: Path) -> None:
+    """Verify directory backup preserves directory permission bits."""
+    # Given: A subdirectory with unusual permissions
+    src = tmp_path / "src"
+    src.mkdir()
+    sub = src / "private"
+    sub.mkdir()
+    sub.chmod(0o700)
+
+    # When: Backing up
+    target = backup_path(src, backup_suffix=".bak")
+
+    # Then: The mirrored subdirectory has the same permission bits
+    assert target is not None
+    assert stat.S_IMODE((target / "private").stat().st_mode) == 0o700
+
+
+def test_backup_directory_follows_symlink_to_file(tmp_path: Path) -> None:
+    """Verify directory backup follows symlinks (resolves to target contents)."""
+    # Given: A directory containing a symlink to a file outside the tree
+    real = tmp_path / "real.txt"
+    real.write_text("content")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "link.txt").symlink_to(real)
+
+    # When: Backing up
+    target = backup_path(src, backup_suffix=".bak")
+
+    # Then: The backup contains the resolved file contents (matches shutil.copytree default)
+    assert target is not None
+    assert (target / "link.txt").is_file()
+    assert not (target / "link.txt").is_symlink()
+    assert (target / "link.txt").read_text() == "content"
+
+
+def test_backup_directory_matches_shutil_copytree_output(tmp_path: Path) -> None:
+    """Verify the chunked walk produces a tree functionally identical to shutil.copytree."""
+    # Given: A non-trivial directory tree
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_text("alpha")
+    (src / "sub").mkdir()
+    (src / "sub" / "b.txt").write_text("beta")
+    (src / "sub" / "empty").mkdir()
+    (src / "sub" / "c.bin").write_bytes(b"\x00\x01\x02\x03")
+
+    # When: Backing up via our chunked walk and via shutil.copytree separately
+    via_backup = backup_path(src, backup_suffix=".ours")
+    via_shutil = src.with_name(src.name + ".shutil")
+    shutil.copytree(src, via_shutil)
+
+    # Then: The two trees contain identical relative paths and file contents
+    assert via_backup is not None
+    ours = sorted(p.relative_to(via_backup) for p in via_backup.rglob("*"))
+    theirs = sorted(p.relative_to(via_shutil) for p in via_shutil.rglob("*"))
+    assert ours == theirs
+    for rel in ours:
+        a = via_backup / rel
+        b = via_shutil / rel
+        if a.is_file():
+            assert a.read_bytes() == b.read_bytes()

--- a/tests/filesystem/test_backup.py
+++ b/tests/filesystem/test_backup.py
@@ -112,27 +112,24 @@ def test_backup_directory(backup_test_path: tuple[Path, Path, Path]) -> None:
 
 
 def test_backup_missing_file(tmp_path: Path) -> None:
-    """Verify backup raises error for missing files when configured."""
-    # Given: A non-existent file path
+    """Verify backup_path raises FileNotFoundError under strict=True when src is missing."""
+    # Given: A path that does not exist
     test_file = tmp_path / "test.txt"
 
-    # When/Then: Backup attempt raises error
+    # When/Then: strict=True surfaces the missing source
     with pytest.raises(FileNotFoundError):
-        backup_path(test_file, raise_on_missing=True)
-
-    assert not test_file.exists()
+        backup_path(test_file, strict=True)
 
 
 def test_backup_missing_file_no_raise(tmp_path: Path) -> None:
-    """Verify backup handles missing files gracefully when configured."""
-    # Given: A non-existent file path
+    """Verify backup_path returns None when src is missing and strict is False."""
+    # Given: A path that does not exist
     test_file = tmp_path / "test.txt"
 
-    # When: Creating backup with raise_on_missing=False
-    output = backup_path(test_file, raise_on_missing=False)
+    # When: Creating backup without strict
+    output = backup_path(test_file, strict=False)
 
-    # Then: No backup created
-    assert not test_file.exists()
+    # Then: Output is None
     assert output is None
 
 

--- a/tests/filesystem/test_copy.py
+++ b/tests/filesystem/test_copy.py
@@ -404,3 +404,32 @@ def test_copy_directory_unified_progress_with_backup(tmp_path: Path) -> None:
     assert "Backup dst" in output
     assert "Copy src" in output
     assert output.index("Backup dst") < output.index("Copy src")
+
+
+@pytest.mark.skipif(not check_python_version(3, 12), reason="Requires Python 3.12+")
+def test_copy_directory_progress_with_symlinked_subdir(tmp_path: Path) -> None:
+    """Verify unified progress reaches 100% for trees containing a symlinked directory."""
+    # Given: A tree with a symlink pointing to a directory containing a file
+    real = tmp_path / "real_dir"
+    real.mkdir()
+    (real / "deep.txt").write_text("deep content")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "regular.txt").write_text("regular content")
+    (src / "link_to_dir").symlink_to(real)
+
+    dst = tmp_path / "dst"
+
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120)
+
+    # When: Copying with progress
+    copy_directory(src, dst, with_progress=True, transient=False, console=console)
+
+    output = buf.getvalue()
+
+    # Then: 100% is shown (would be missed if _sum_bytes didn't follow symlinks)
+    assert "100%" in output
+    # And: The symlink target's content was copied
+    assert (dst / "link_to_dir" / "deep.txt").read_text() == "deep content"

--- a/tests/filesystem/test_copy.py
+++ b/tests/filesystem/test_copy.py
@@ -353,3 +353,54 @@ def test_copy_file_uses_provided_console(tmp_path: Path) -> None:
 
     # Then: Progress output landed on the supplied console, not stdout
     assert "Copy test.txt" in buffer.getvalue()
+
+
+@pytest.mark.skipif(not check_python_version(3, 12), reason="Requires Python 3.12+")
+def test_copy_directory_unified_progress_no_backup(tmp_path: Path) -> None:
+    """Verify copy_directory shows a single Copy phase when dst does not exist."""
+    # Given: A source directory with a couple of files, no pre-existing dst
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_text("hello")
+    (src / "b.txt").write_text("world")
+    dst = tmp_path / "dst"
+
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120)
+
+    # When: Copying with progress and a non-transient bar
+    copy_directory(src, dst, with_progress=True, transient=False, console=console)
+
+    output = buf.getvalue()
+
+    # Then: One Copy phase header appears, no Backup phase header
+    assert "Copy src" in output
+    assert "Backup" not in output
+    # And: 100% completion is shown
+    assert "100%" in output
+
+
+@pytest.mark.skipif(not check_python_version(3, 12), reason="Requires Python 3.12+")
+def test_copy_directory_unified_progress_with_backup(tmp_path: Path) -> None:
+    """Verify copy_directory shows Backup then Copy when dst exists."""
+    # Given: An existing dst directory and a fresh src
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "new.txt").write_text("new content")
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / "old.txt").write_text("old content")
+
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120)
+
+    # When: Copying with progress, backup enabled, non-transient
+    copy_directory(src, dst, with_progress=True, transient=False, keep_backup=True, console=console)
+
+    output = buf.getvalue()
+
+    # Then: Both Backup and Copy phase headers appear, in order
+    assert "Backup dst" in output
+    assert "Copy src" in output
+    assert output.index("Backup dst") < output.index("Copy src")

--- a/tests/filesystem/test_copy.py
+++ b/tests/filesystem/test_copy.py
@@ -1,5 +1,6 @@
 """Test the copy_file function."""
 
+import shutil
 from collections.abc import Callable
 from io import StringIO
 from pathlib import Path
@@ -404,6 +405,42 @@ def test_copy_directory_unified_progress_with_backup(tmp_path: Path) -> None:
     assert "Backup dst" in output
     assert "Copy src" in output
     assert output.index("Backup dst") < output.index("Copy src")
+
+
+def test_copy_file_same_file_strict_raises(tmp_path: Path) -> None:
+    """Verify copy_file raises shutil.SameFileError when strict=True and src == dst."""
+    # Given: A file that exists
+    f = tmp_path / "test.txt"
+    f.write_text("hi")
+
+    # When/Then: Copying a file to itself under strict raises SameFileError
+    with pytest.raises(shutil.SameFileError):
+        copy_file(f, f, strict=True)
+
+
+@pytest.mark.skipif(not check_python_version(3, 12), reason="Requires Python 3.12+")
+def test_copy_directory_same_dir_strict_raises(tmp_path: Path) -> None:
+    """Verify copy_directory raises shutil.SameFileError when strict=True and src == dst."""
+    # Given: A directory
+    d = tmp_path / "d"
+    d.mkdir()
+
+    # When/Then: Copying a directory to itself under strict raises SameFileError
+    with pytest.raises(shutil.SameFileError):
+        copy_directory(d, d, strict=True)
+
+
+@pytest.mark.skipif(not check_python_version(3, 12), reason="Requires Python 3.12+")
+def test_copy_directory_parent_child_strict_raises(tmp_path: Path) -> None:
+    """Verify copy_directory raises ValueError when strict=True and src/dst are nested."""
+    # Given: src and dst in a parent-child relationship
+    src = tmp_path / "parent"
+    src.mkdir()
+    dst = src / "child"
+
+    # When/Then: Nested src/dst under strict raises ValueError
+    with pytest.raises(ValueError, match="parent/child"):
+        copy_directory(src, dst, strict=True)
 
 
 @pytest.mark.skipif(not check_python_version(3, 12), reason="Requires Python 3.12+")

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -248,6 +248,17 @@ def test_clean_directory_not_a_directory(
     assert "test.txt is not a directory. Did not clean" in fs_caplog.text
 
 
+def test_clean_directory_not_a_directory_strict_raises(tmp_path: Path) -> None:
+    """Verify clean_directory raises NotADirectoryError when strict=True and target is not a directory."""
+    # Given: A path that is a file, not a directory
+    f = tmp_path / "not_a_dir.txt"
+    f.write_text("hi")
+
+    # When/Then: strict=True turns the silent log into NotADirectoryError
+    with pytest.raises(NotADirectoryError):
+        clean_directory(f, strict=True)
+
+
 def test_clean_directory_removes_symlink_to_directory(tmp_path: Path) -> None:
     """Verify clean_directory unlinks directory symlinks instead of recursing into them."""
     # Given: A directory containing a symlink that points at another directory

--- a/tests/filesystem/test_find_user_home.py
+++ b/tests/filesystem/test_find_user_home.py
@@ -74,3 +74,28 @@ def test_find_user_home_dir_pwd_unavailable_returns_none_and_warns(
     # Then: None is returned and a warning was logged
     assert result is None
     assert "pwd module" in caplog.text
+
+
+def test_find_user_home_dir_unknown_user_strict_raises(fake_pwd) -> None:
+    """Verify find_user_home_dir raises KeyError when strict=True and user is unknown."""
+    # Given: pwd.getpwnam raises KeyError for the requested user
+    fake_pwd(side_effect=KeyError("ghost"))
+
+    # When/Then: strict=True turns the silent return into KeyError
+    with pytest.raises(KeyError):
+        find_user_home_dir("ghost", strict=True)
+
+
+def test_find_user_home_dir_pwd_unavailable_returns_none_even_under_strict(
+    mocker, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify find_user_home_dir keeps returning None for missing pwd module even under strict."""
+    # Given: pwd cannot be imported
+    mocker.patch.dict(sys.modules, {"pwd": None})
+    caplog.set_level("WARNING", logger="nclutils.fs.filesystem")
+
+    # When: Looking up under strict=True
+    result = find_user_home_dir("anyone", strict=True)
+
+    # Then: Still None (platform capability, not a strict-mode violation)
+    assert result is None

--- a/tests/filesystem/test_helpers.py
+++ b/tests/filesystem/test_helpers.py
@@ -1,0 +1,47 @@
+"""Tests for module-private helpers in nclutils.fs.filesystem."""
+
+from pathlib import Path
+
+from nclutils.fs.filesystem import _sum_bytes
+
+
+def test_sum_bytes_empty_directory(tmp_path: Path) -> None:
+    """Verify _sum_bytes returns (0, 0) for an empty directory."""
+    # Given: An empty directory
+    # When: Summing bytes
+    total, count = _sum_bytes(tmp_path)
+
+    # Then: Both are zero
+    assert total == 0
+    assert count == 0
+
+
+def test_sum_bytes_flat_directory(tmp_path: Path) -> None:
+    """Verify _sum_bytes returns total bytes and file count for a flat directory."""
+    # Given: A directory with two files of known sizes
+    (tmp_path / "a.txt").write_bytes(b"hello")  # 5 bytes
+    (tmp_path / "b.txt").write_bytes(b"world!")  # 6 bytes
+
+    # When: Summing bytes
+    total, count = _sum_bytes(tmp_path)
+
+    # Then: Sizes and count match
+    assert total == 11
+    assert count == 2
+
+
+def test_sum_bytes_recursive(tmp_path: Path) -> None:
+    """Verify _sum_bytes recurses into subdirectories."""
+    # Given: A nested directory tree with three files
+    (tmp_path / "a.txt").write_bytes(b"a")  # 1 byte
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.txt").write_bytes(b"bb")  # 2 bytes
+    (tmp_path / "sub" / "deep").mkdir()
+    (tmp_path / "sub" / "deep" / "c.txt").write_bytes(b"ccc")  # 3 bytes
+
+    # When: Summing bytes
+    total, count = _sum_bytes(tmp_path)
+
+    # Then: Recurses through all levels
+    assert total == 6
+    assert count == 3


### PR DESCRIPTION
## Summary

Three changes to `nclutils.fs`, bundled per design discussion:

- **`_Copier` internal class.** Public `copy_file` / `copy_directory` / `backup_path` become thin wrappers that build a one-shot `_Copier(with_progress, transient, console, strict)` and delegate. Eliminates kwarg sprawl and lets a single `Progress` instance flow through directory operations.
- **Unified `strict` kwarg.** Every silent-path function (`backup_path`, `copy_file`, `copy_directory`, `clean_directory`, `find_user_home_dir`) gains `strict: bool = False`. Default behavior is unchanged; `strict=True` raises a stdlib-idiom exception per the table below. The `find_user_home_dir` "no `pwd` module" path always returns `None` regardless of `strict` (platform capability, not a runtime error).
- **Two-phase progress for `copy_directory`.** When `with_progress=True`, one outer total-bytes task plus one recycled per-file subtask. When `keep_backup=True` and `dst` exists, two sequential `Progress` lifecycles (Backup → Copy), eliminating the per-file bar flicker.

The directory backup path was reimplemented as a chunked `Path.walk(follow_symlinks=True)` so it can drive the same `Progress` machinery (replacing `shutil.copytree`). Behavior is functionally equivalent to `shutil.copytree(src, target)` defaults: follows symlinks (including symlinked subdirectories), preserves directory mode + timestamps, preserves file mode (file mtime is not preserved because the write bumps it), creates empty subdirs.

### `strict=True` behavior

| Function | Failure | strict=True |
| --- | --- | --- |
| `backup_path` | src missing | `FileNotFoundError` |
| `copy_file` | src == dst | `shutil.SameFileError` |
| `copy_directory` | src == dst | `shutil.SameFileError` |
| `copy_directory` | src/dst parent-child | `ValueError` |
| `clean_directory` | not a directory | `NotADirectoryError` |
| `find_user_home_dir` | unknown user | `KeyError` |
| `find_user_home_dir` | no `pwd` module | (always `None`) |

## Breaking change

`backup_path(..., raise_on_missing=True)` is removed. Replace with `backup_path(..., strict=True)`. No deprecation shim; calls with the old kwarg will `TypeError`. Marked with `feat(fs)!:` in commit `78cfdb4`.

`copy_directory` and `backup_path` (when given a directory) now require Python 3.12+ for the underlying `Path.walk()`. File-only `backup_path` and the rest of the module continue to work on Python 3.10+.

## Test plan

- [x] Full pytest suite passes (323 tests, was 304)
- [x] `ruff check` and `ruff format` clean
- [x] `mypy` clean
- [x] Verify the chunked-walk directory backup matches `shutil.copytree(src, target)` output (`test_backup_directory_matches_shutil_copytree_output`)
- [x] Verify symlink-to-directory is followed in both `backup_path` and `copy_directory` paths
- [x] Verify two-phase progress appears in `copy_directory(with_progress=True, keep_backup=True)` against an existing destination (Backup phase, then Copy phase)
- [x] Verify `_sum_bytes` and the actual copy walk agree on symlinked subdirectories (regression test added)
- [x] Verify each `strict=True` failure raises the correct stdlib exception type
- [x] Verify the `pwd`-missing path in `find_user_home_dir` stays silent under `strict=True`
- [ ] Manual smoke test on a real directory copy with `with_progress=True` to confirm the bar UX in a terminal

## Notes

- Spec at `docs/superpowers/specs/2026-05-06-fs-copier-and-error-policy-design.md` (not committed; per project convention `docs/superpowers/` is gitignored).
- Plan at `docs/superpowers/plans/2026-05-06-fs-copier-and-error-policy.md` (same).
- Branch is 13 commits, each atomic. History reads cleanly via \`git log --oneline main..HEAD\`.