### PR TITLE
refactor(pp)!: rename pretty_print module to pp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,11 @@ uv run pytest tests/filesystem/test_copy.py -k "backup"
 - `src/nclutils/<module>/__init__.py` — re-exports the public surface and defines `__all__`.
 - `src/nclutils/<module>/<implementation>.py` — actual code.
 
-Only `pretty_print` is re-exported at the package root (`from nclutils import info, success, ...`). Every other module must be imported from its submodule (`from nclutils.fs import copy_file`). Preserve this convention — it's the public API contract and is documented in the README.
+Every module must be imported from its submodule. The preferred form for the pretty-printer is `from nclutils import pp` and call sites use `pp.info(...)`, `pp.success(...)`, etc.; individual symbols may also be pulled with `from nclutils.pp import info`. Other modules follow the same pattern (`from nclutils.fs import copy_file`). Preserve this convention — it's the public API contract and is documented in the README.
 
-`tests/` mirrors the source layout. Larger modules have their own subdirectory (`tests/filesystem/`, `tests/pretty_print/`), each with its own `conftest.py`. Smaller modules use a single `tests/test_<module>.py` file.
+`tests/` mirrors the source layout. Larger modules have their own subdirectory (`tests/filesystem/`, `tests/pp/`), each with its own `conftest.py`. Smaller modules use a single `tests/test_<module>.py` file.
 
-`docs/` contains per-module guides (`fs.md`, `strings.md`, `utils.md`, `pretty_print.md`, `questions.md`, `shell_commands.md`). The README is an index; the `docs/` pages are the deep dives.
+`docs/` contains per-module guides (`fs.md`, `strings.md`, `utils.md`, `pp.md`, `questions.md`, `shell_commands.md`). The README is an index; the `docs/` pages are the deep dives.
 
 **Always update documentation when code changes.** Any change that affects a public function's signature, behavior, defaults, exceptions, or examples must be reflected in the matching `docs/<module>.md` page (and the README's module summary table if the surface area shifts). New public exports must be added to the relevant `__init__.py`'s `__all__`, the module's API reference section in `docs/`, and the README. Removing or renaming a public symbol is a breaking change — update the docs in the same commit.
 
@@ -45,10 +45,10 @@ Only `pretty_print` is re-exported at the package root (`from nclutils import in
 
 The project has two parallel output paths and they are intentionally separate:
 
-1. **`nclutils.pretty_print`** — Rich-based user-facing CLI output (`info`, `success`, `error`, `step()`, etc.). The `Emitter` class owns this, with module-level functions delegating to a shared default. Has its own theme, verbosity gates, and optional file logger.
+1. **`nclutils.pp`** — Rich-based user-facing CLI output (`info`, `success`, `error`, `step()`, etc.). The `Emitter` class owns this, with module-level functions delegating to a shared default. Has its own theme, verbosity gates, and optional file logger.
 2. **stdlib `logging`** — internal diagnostics inside `nclutils.fs` and `nclutils.text_processing`. Each module logs under `nclutils.<module>` and is silent unless the host application attaches a handler.
 
-Do not bridge these. `nclutils.fs` does not call `pretty_print`; `pretty_print` does not call stdlib `logging` for its own output. The project recently migrated off `loguru` (commit 6cafada) — any older guidance referencing `loguru` (including `.cursor/rules/python_preferred_tools.mdc`) is stale.
+Do not bridge these. `nclutils.fs` does not call `pp`; `pp` does not call stdlib `logging` for its own output. The project recently migrated off `loguru` (commit 6cafada) — any older guidance referencing `loguru` (including `.cursor/rules/python_preferred_tools.mdc`) is stale.
 
 ## Testing conventions
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Comprehensive tests are included, but this package is written and maintained for
 
 ```python
 from pathlib import Path
-from nclutils import info, success, step
+from nclutils import pp
 from nclutils.fs import copy_file, find_files
 from nclutils.strings import snake_case
 
-info("collecting Python sources")
+pp.info("collecting Python sources")
 
-with step("copying files") as s:
+with pp.step("copying files") as s:
     for src in find_files(Path("src"), globs=["*.py"]):
         dst = Path("backup") / src.name
         copy_file(src, dst)
         s.sub(f"copied {src.name}")
 
-success(f"normalized name: {snake_case('Hello World')}")
+pp.success(f"normalized name: {snake_case('Hello World')}")
 ```
 
 ## Installation
@@ -41,13 +41,16 @@ The package brings in two runtime dependencies: [questionary](https://github.com
 
 ## Importing
 
-Pretty-printing helpers are re-exported at the package root for convenience:
+Each module is imported from its submodule. The pretty-printing helpers are namespaced under `pp`:
 
 ```python
-from nclutils import info, success, error, step, configure, Verbosity
+from nclutils import pp
+
+pp.info("hello")
+pp.success("done")
 ```
 
-Everything else lives in its submodule and must be imported from there:
+Other modules follow the same pattern:
 
 ```python
 from nclutils.fs import copy_file, find_files
@@ -59,6 +62,12 @@ from nclutils.text_processing import replace_in_file
 from nclutils.utils import iso_timestamp, unique_id
 ```
 
+Individual `pp` symbols can also be imported directly when that reads better at the call site:
+
+```python
+from nclutils.pp import info, success
+```
+
 ## Modules
 
 The larger modules have their own documentation pages. Smaller modules are listed inline below. Function signatures live with the source; consult docstrings (`help(func)` or your editor's hover) for authoritative argument details.
@@ -67,7 +76,7 @@ The larger modules have their own documentation pages. Smaller modules are liste
 | ------------------------- | -------------------------------------------------------- | ------------------------------------- |
 | `nclutils.fs`             | Copy, back up, search, and visualize the filesystem.     | [docs/fs.md](docs/fs.md)              |
 | `nclutils.network`        | Lightweight network reachability check.                  | _(inline below)_                      |
-| `nclutils.pretty_print`   | Rich-based console output, verbosity gates, file logger. | [docs/pretty_print.md](docs/pretty_print.md) |
+| `nclutils.pp`             | Rich-based console output, verbosity gates, file logger. | [docs/pp.md](docs/pp.md)              |
 | `nclutils.questions`      | Single- and multi-select prompts via `questionary`.      | [docs/questions.md](docs/questions.md) |
 | `nclutils.sh`             | Run commands via subprocess; returns `CompletedCommand`, raises typed errors (`ShellCommandError` hierarchy). Includes `run_command`, `run_interactive`, `which`. | [docs/shell_commands.md](docs/shell_commands.md) |
 | `nclutils.strings`        | Case conversions, padding, tokenizing, normalization.    | [docs/strings.md](docs/strings.md)    |
@@ -106,7 +115,7 @@ logging.basicConfig(level=logging.WARNING)
 logging.getLogger("nclutils").setLevel(logging.DEBUG)
 ```
 
-This is separate from `nclutils.pretty_print`, which writes to the console (and optionally a logfile) using its own machinery.
+This is separate from `nclutils.pp`, which writes to the console (and optionally a logfile) using its own machinery.
 
 ## Contributing
 

--- a/docs/fs.md
+++ b/docs/fs.md
@@ -35,13 +35,13 @@ copy_file(src, dst, keep_backup=False)
 
 For `copy_directory(..., with_progress=True)`, the bar shows the total bytes across all files plus a recycled per-file subtask. When `keep_backup=True` and the destination already exists, you'll see two sequential phases: a Backup phase (snapshotting the existing destination) that dismisses on completion, then a Copy phase. Each phase has its own progress bar.
 
-Pass `console=` to route the progress bar through your own Rich `Console` instead of Rich's global default. This is useful when you want the bar to share a console with `pretty_print.console()`:
+Pass `console=` to route the progress bar through your own Rich `Console` instead of Rich's global default. This is useful when you want the bar to share a console with `pp.console()`:
 
 ```python
-from nclutils import console
+from nclutils import pp
 from nclutils.fs import copy_file
 
-copy_file(src, dst, with_progress=True, console=console())
+copy_file(src, dst, with_progress=True, console=pp.console())
 ```
 
 > [!NOTE]
@@ -151,11 +151,11 @@ from nclutils.fs import directory_tree
 Console().print(directory_tree(Path("./src"), show_hidden=False))
 ```
 
-Pair it with `pretty_print.console()` to render through the same console that the rest of `nclutils` uses:
+Pair it with `pp.console()` to render through the same console that the rest of `nclutils` uses:
 
 ```python
-from nclutils import console
-console().print(directory_tree(Path("./src")))
+from nclutils import pp
+pp.console().print(directory_tree(Path("./src")))
 ```
 
 ## Looking up a user's home directory
@@ -185,7 +185,7 @@ logging.getLogger("nclutils.fs").setLevel(logging.DEBUG)
 logging.basicConfig()
 ```
 
-This is independent of `nclutils.pretty_print`. It covers internal operations like "starting a copy" or "skipping a backup because the source is missing."
+This is independent of `nclutils.pp`. It covers internal operations like "starting a copy" or "skipping a backup because the source is missing."
 
 ## API reference
 

--- a/docs/pp.md
+++ b/docs/pp.md
@@ -3,10 +3,10 @@
 Themed console output and file logging for Python CLI scripts. A thin layer over [Rich](https://github.com/Textualize/rich) that gives you `info` / `success` / `warning` / `error` / `debug` / `trace` / `dryrun` calls, a spinner-driven `step()` context manager, and an optional parallel logfile.
 
 ```python
-from nclutils import success, warning
+from nclutils import pp
 
-success("deployed to production")
-warning("API rate limit at 80%")
+pp.success("deployed to production")
+pp.warning("API rate limit at 80%")
 ```
 
 ```
@@ -17,93 +17,93 @@ warning("API rate limit at 80%")
 
 ## What it owns
 
-`pretty_print` handles the four things that grow out of `print()` in any non-trivial CLI script: the verbosity gates (`--verbose` / `--quiet`), the stdout/stderr split, Rich-markup escaping for untrusted input, and a preset theme.
+`pp` handles the four things that grow out of `print()` in any non-trivial CLI script: the verbosity gates (`--verbose` / `--quiet`), the stdout/stderr split, Rich-markup escaping for untrusted input, and a preset theme.
 
 ## Quick start
 
 ```python
 import time
-from nclutils import configure, info, success, step, Verbosity
+from nclutils import pp
 
-configure(verbosity=Verbosity.DEBUG)
+pp.configure(verbosity=pp.Verbosity.DEBUG)
 
-info("starting build")
+pp.info("starting build")
 
-with step("compiling sources") as s:
+with pp.step("compiling sources") as s:
     time.sleep(0.5)
     s.sub("compiling src/api.py")
     s.sub("compiling src/cli.py")
 
-success("build complete", details=["artifact: dist/app-1.4.2.tar.gz"])
+pp.success("build complete", details=["artifact: dist/app-1.4.2.tar.gz"])
 ```
 
-The `step()` block shows a live spinner with sub-items beneath it. On success it turns into a green checkmark; on any exception (including `SystemExit` and `KeyboardInterrupt`) it turns into a red X and the exception re-raises.
+The `pp.step()` block shows a live spinner with sub-items beneath it. On success it turns into a green checkmark; on any exception (including `SystemExit` and `KeyboardInterrupt`) it turns into a red X and the exception re-raises.
 
 ## Output levels
 
-Every level routes through the same shape: `func(message, details=[...])`. `details` is optional. String items render as indented continuation lines in a dimmer shade; Rich markup is escaped by default so user-supplied strings can't inject styling. Non-strings are auto-rendered with Rich (dicts, dataclasses, and arbitrary objects via `Pretty`; `JSON` / `Syntax` / `Table` pass through unchanged).
+Every level routes through the same shape: `pp.func(message, details=[...])`. `details` is optional. String items render as indented continuation lines in a dimmer shade; Rich markup is escaped by default so user-supplied strings can't inject styling. Non-strings are auto-rendered with Rich (dicts, dataclasses, and arbitrary objects via `Pretty`; `JSON` / `Syntax` / `Table` pass through unchanged).
 
 Pass `markup=True` to opt into Rich markup parsing for `message` and any string `details` items in that call:
 
 ```python
 from rich.text import Text
-from nclutils import info
+from nclutils import pp
 
-info("Found [bold]42[/] matches", markup=True)
-info(Text.from_markup("Found [bold]42[/] matches"))  # Text instances always keep their styling
+pp.info("Found [bold]42[/] matches", markup=True)
+pp.info(Text.from_markup("Found [bold]42[/] matches"))  # Text instances always keep their styling
 ```
 
 Use `markup=True` when _you_ control the string. When the message comes from arbitrary input (file paths, exception messages, JSON snippets), keep the default escape so brackets in the input can't accidentally render as styling or raise `MarkupError`.
 
-| Function   | Stream | Marker                   | Gated by                   |
-| ---------- | ------ | ------------------------ | -------------------------- |
-| `info`     | stdout | (none)                   | `quiet` suppresses         |
-| `success`  | stdout | `✓`                      | `quiet` suppresses         |
-| `warning`  | stderr | `!`                      | always renders             |
-| `error`    | stderr | `✗`                      | always renders             |
-| `critical` | stderr | `‼`                      | always renders             |
-| `dryrun`   | stdout | `~ [dry-run]`            | always renders             |
-| `debug`    | stdout | `›`                      | shown at `DEBUG` or higher |
-| `trace`    | stdout | `·`                      | shown at `TRACE`           |
-| `header`   | stdout | (rule line)              | `quiet` suppresses         |
-| `step`     | stdout | spinner, then `✓` or `✗` | always renders             |
+| Function      | Stream | Marker                   | Gated by                   |
+| ------------- | ------ | ------------------------ | -------------------------- |
+| `pp.info`     | stdout | (none)                   | `quiet` suppresses         |
+| `pp.success`  | stdout | `✓`                      | `quiet` suppresses         |
+| `pp.warning`  | stderr | `!`                      | always renders             |
+| `pp.error`    | stderr | `✗`                      | always renders             |
+| `pp.critical` | stderr | `‼`                      | always renders             |
+| `pp.dryrun`   | stdout | `~ [dry-run]`            | always renders             |
+| `pp.debug`    | stdout | `›`                      | shown at `DEBUG` or higher |
+| `pp.trace`    | stdout | `·`                      | shown at `TRACE`           |
+| `pp.header`   | stdout | (rule line)              | `quiet` suppresses         |
+| `pp.step`     | stdout | spinner, then `✓` or `✗` | always renders             |
 
-`critical` is severity-only and does not raise. Use it for "the world is broken" notices that warrant a more emphatic visual than `error`.
+`pp.critical` is severity-only and does not raise. Use it for "the world is broken" notices that warrant a more emphatic visual than `pp.error`.
 
 You can pass Rich renderables in `details` to get syntax-aware output, which is especially useful at `debug` / `trace`:
 
 ```python
 from rich.json import JSON
-from nclutils import debug
+from nclutils import pp
 
-debug("got response", details=[response_dict])
-debug("raw payload", details=[JSON(resp.text)])
+pp.debug("got response", details=[response_dict])
+pp.debug("raw payload", details=[JSON(resp.text)])
 ```
 
-`header()` draws a `Console.rule()` with an optional centered title to break long output into scannable sections:
+`pp.header()` draws a `Console.rule()` with an optional centered title to break long output into scannable sections:
 
 ```python
-from nclutils import header
+from nclutils import pp
 
-header("phase 1: download")
+pp.header("phase 1: download")
 # ... work ...
-header("phase 2: process")
+pp.header("phase 2: process")
 ```
 
 ## Wiring up `--verbose` and `--quiet`
 
-`Verbosity` is an `IntEnum` with three levels (`INFO`, `DEBUG`, `TRACE`), so a `-v` count flag maps cleanly:
+`pp.Verbosity` is an `IntEnum` with three levels (`INFO`, `DEBUG`, `TRACE`), so a `-v` count flag maps cleanly:
 
 ```python
 import argparse
-from nclutils import configure, Verbosity
+from nclutils import pp
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-v", "--verbose", action="count", default=0)
 parser.add_argument("-q", "--quiet", action="store_true")
 args = parser.parse_args()
 
-configure(verbosity=args.verbose, quiet=args.quiet)
+pp.configure(verbosity=args.verbose, quiet=args.quiet)
 ```
 
 Out-of-range integers are clamped, so `-vvvvv` is safe.
@@ -114,21 +114,21 @@ The two flags are independent gates:
 - `quiet=True` suppresses `info`, `success`, and `header`. Warnings, errors, dry-run notices, and steps still render.
 - `--verbose --quiet` is a sensible combination: you get debug output without the routine info chatter.
 
-`configure()` is a partial update. Fields you don't pass are left alone. Call it as many times as you like:
+`pp.configure()` is a partial update. Fields you don't pass are left alone. Call it as many times as you like:
 
 ```python
-configure(verbosity=Verbosity.DEBUG)
-configure(quiet=True)         # verbosity still DEBUG
+pp.configure(verbosity=pp.Verbosity.DEBUG)
+pp.configure(quiet=True)         # verbosity still DEBUG
 ```
 
 ## The `step()` context manager
 
-`step()` renders a Rich `Live` spinner that updates while your code runs, then resolves to a success or failure marker:
+`pp.step()` renders a Rich `Live` spinner that updates while your code runs, then resolves to a success or failure marker:
 
 ```python
-from nclutils import step
+from nclutils import pp
 
-with step("running migrations") as s:
+with pp.step("running migrations") as s:
     for migration in pending:
         run(migration)
         s.sub(f"applied {migration.name}")
@@ -139,14 +139,14 @@ On exit the spinner stops, the marker (`✓` or `✗`) is rendered, and any sub-
 For transient progress that shouldn't clutter the final transcript, pass `ephemeral=True`. The spinner and sub-items are wiped on success; on failure only the red X surfaces:
 
 ```python
-with step("warming caches", ephemeral=True) as s:
+with pp.step("warming caches", ephemeral=True) as s:
     warm_cache()
     s.sub("cache populated")
 # success leaves no trace; failure still prints "✗ warming caches"
 ```
 
 > [!WARNING]
-> `step()` cannot nest. Rich's `Live` doesn't stack, so nesting silently corrupts the parent's display. `pretty_print` raises `RuntimeError` when you try.
+> `pp.step()` cannot nest. Rich's `Live` doesn't stack, so nesting silently corrupts the parent's display. `pp` raises `RuntimeError` when you try.
 
 ## File logging
 
@@ -154,11 +154,11 @@ Pass `logfile=` to write a parallel record of every emission to disk:
 
 ```python
 from pathlib import Path
-from nclutils import Emitter, LogLevel
+from nclutils import pp
 
-e = Emitter(
+e = pp.Emitter(
     logfile=Path("./run.log"),
-    loglevel=LogLevel.INFO,        # default; filter cutoff for the file
+    loglevel=pp.LogLevel.INFO,        # default; filter cutoff for the file
     # logfmt="%(asctime)s [%(levelname)s] %(message)s",  # optional override
 )
 
@@ -194,60 +194,60 @@ Console rendering and file rendering are independent. The console ignores `logle
 | `Step.sub()`                  | `INFO`                            | Indented continuation, written immediately.                                   |
 | `header()`                    | (not logged)                      | Console-only structural sugar.                                                |
 
-Filtering with `loglevel=LogLevel.WARNING` drops every `info` / `success` / `dryrun` / `debug` / `trace` emission and its detail continuations as a unit. `LogLevel` is severity-shaped, not emission-shaped, so there's no way to "log only successes."
+Filtering with `loglevel=pp.LogLevel.WARNING` drops every `info` / `success` / `dryrun` / `debug` / `trace` emission and its detail continuations as a unit. `LogLevel` is severity-shaped, not emission-shaped, so there's no way to "log only successes."
 
 ### What's not included
 
-The logfile is for CLI audit and diagnostic capture. It does not ship rotation, JSON output, syslog, or multi-process safety. If you need those, run `pretty_print` on top of your own preconfigured `logging.Logger`, or use external rotation (`logrotate`, `savelog`).
+The logfile is for CLI audit and diagnostic capture. It does not ship rotation, JSON output, syslog, or multi-process safety. If you need those, run `pp` on top of your own preconfigured `logging.Logger`, or use external rotation (`logrotate`, `savelog`).
 
 ## Customizing the theme
 
 The seven output levels (`info`, `success`, `warning`, `error`, `debug`, `trace`, `dryrun`) each expose three things you can override: the main message style, the indented detail style, and the marker glyph. Override any combination in a `Theme`:
 
 ```python
-from nclutils import configure, Theme, Level, success
+from nclutils import pp
 
-configure(
-    theme=Theme(
-        success=Level(style="cyan", marker="🎉 "),
-        warning=Level(marker=""),  # hide the warning marker entirely
+pp.configure(
+    theme=pp.Theme(
+        success=pp.Level(style="cyan", marker="🎉 "),
+        warning=pp.Level(marker=""),  # hide the warning marker entirely
     ),
 )
 
-success("deployed", details=["build #1742"])
+pp.success("deployed", details=["build #1742"])
 ```
 
-Anything you don't set keeps its default. `Level(style="cyan")` only changes the main color; `detail_style` and `marker` stay as the defaults. Pass `marker=""` (empty string) to suppress a marker; `marker=None` (the default) keeps the built-in glyph.
+Anything you don't set keeps its default. `pp.Level(style="cyan")` only changes the main color; `detail_style` and `marker` stay as the defaults. Pass `marker=""` (empty string) to suppress a marker; `marker=None` (the default) keeps the built-in glyph.
 
-Successive `configure(theme=...)` calls accumulate at the field level:
+Successive `pp.configure(theme=...)` calls accumulate at the field level:
 
 ```python
-from nclutils import configure, Theme, Level, success
+from nclutils import pp
 
-configure(theme=Theme(success=Level(style="blue", marker="🎉 ")))
-configure(theme=Theme(success=Level(detail_style="navy")))
+pp.configure(theme=pp.Theme(success=pp.Level(style="blue", marker="🎉 ")))
+pp.configure(theme=pp.Theme(success=pp.Level(detail_style="navy")))
 # success now has style="blue", detail_style="navy", marker="🎉 "
 ```
 
-To fully reset, build a fresh emitter: `set_default(Emitter())`.
+To fully reset, build a fresh emitter: `pp.set_default(pp.Emitter())`.
 
 ### What's not themed
 
-The horizontal rule under `header()`, the connector glyphs beneath `step()` (`├─`, `└─`), and the `[dry-run]` tag are not customizable.
+The horizontal rule under `pp.header()`, the connector glyphs beneath `pp.step()` (`├─`, `└─`), and the `[dry-run]` tag are not customizable.
 
 ## Reaching the underlying consoles
 
-When you need to render a Rich object (`Table`, `Syntax`, `Panel`, …) on the same stream the level functions write to, use the `console()` and `err_console()` accessors:
+When you need to render a Rich object (`Table`, `Syntax`, `Panel`, …) on the same stream the level functions write to, use the `pp.console()` and `pp.err_console()` accessors:
 
 ```python
 from rich.table import Table
-from nclutils import console, err_console
+from nclutils import pp
 
 table = Table("name", "status")
 table.add_row("api", "ok")
-console().print(table)
+pp.console().print(table)
 
-err_console().print("[bold red]fatal[/]")
+pp.err_console().print("[bold red]fatal[/]")
 ```
 
 ## Library use: isolated emitters
@@ -255,9 +255,9 @@ err_console().print("[bold red]fatal[/]")
 The module-level functions delegate to a shared default `Emitter`. If you're writing a library that needs its own output configuration without trampling its host CLI's settings, instantiate an `Emitter` directly:
 
 ```python
-from nclutils import Emitter, Verbosity
+from nclutils import pp
 
-logger = Emitter(verbosity=Verbosity.DEBUG, quiet=False)
+logger = pp.Emitter(verbosity=pp.Verbosity.DEBUG, quiet=False)
 logger.info("library-internal message")
 logger.debug("only this emitter's verbosity matters here")
 ```
@@ -268,10 +268,10 @@ For tests, swap in a recording console so you can assert on output:
 
 ```python
 from rich.console import Console
-from nclutils import Emitter, THEME
+from nclutils import pp
 
-capture = Console(theme=THEME, record=True, force_terminal=True, width=80)
-e = Emitter(console=capture, err_console=capture)
+capture = Console(theme=pp.THEME, record=True, force_terminal=True, width=80)
+e = pp.Emitter(console=capture, err_console=capture)
 e.info("captured")
 assert "captured" in capture.export_text()
 ```
@@ -279,24 +279,24 @@ assert "captured" in capture.export_text()
 > [!NOTE]
 > Use the `theme=` argument to customize level styles, not a custom `Console(theme=...)`. Level styles are resolved inline at print time, so a theme dict on a user-supplied `Console` no longer overrides level rendering.
 >
-> The `Console(theme=THEME)` pattern is still valid when you need to capture the default theme's structural styles (`header`, `header.rule`, `sub.pipe`) on your own console.
+> The `Console(theme=pp.THEME)` pattern is still valid when you need to capture the default theme's structural styles (`header`, `header.rule`, `sub.pipe`) on your own console.
 
 To route the module-level functions through a test emitter:
 
 ```python
-from nclutils import set_default, get_default
+from nclutils import pp
 
-original = get_default()
-set_default(e)
+original = pp.get_default()
+pp.set_default(e)
 try:
     run_code_under_test()
 finally:
-    set_default(original)
+    pp.set_default(original)
 ```
 
 ## API reference
 
-Every name below is re-exported from `nclutils` for convenience and is also available from `nclutils.pretty_print`.
+Every name below is available on the `pp` namespace (`from nclutils import pp`) and from `nclutils.pp` directly (e.g. `from nclutils.pp import info`).
 
 - `info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`, `header`. Output functions.
 - `step(message, *, ephemeral=False)`. Spinner context manager.

--- a/docs/shell_commands.md
+++ b/docs/shell_commands.md
@@ -1,6 +1,6 @@
 # Shell commands
 
-A thin wrapper over stdlib `subprocess` for running external commands. Imported from `nclutils.sh`. Results come back as a typed `CompletedCommand` dataclass rather than raw strings, and every failure mode maps to a specific exception class. Output goes to `sys.stdout`/`sys.stderr` directly; `nclutils.sh` does not route through `nclutils.pretty_print`'s console.
+A thin wrapper over stdlib `subprocess` for running external commands. Imported from `nclutils.sh`. Results come back as a typed `CompletedCommand` dataclass rather than raw strings, and every failure mode maps to a specific exception class. Output goes to `sys.stdout`/`sys.stderr` directly; `nclutils.sh` does not route through `nclutils.pp`'s console.
 
 ```python
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@
             "PLR6301",
             "S101",
             "SLF001",  # Access a private attribute
-        ], "duties.py" = ["ANN001", "FBT001", "FBT002"], "src/nclutils/pretty_print/emitter.py" = [
+        ], "duties.py" = ["ANN001", "FBT001", "FBT002"], "src/nclutils/pp/emitter.py" = [
             "ANN401", # Dynamically typed expressions (typing.Any) are disallowed in `**kwargs`
         ] }
         select = ["ALL"]

--- a/src/nclutils/__init__.py
+++ b/src/nclutils/__init__.py
@@ -1,54 +1,10 @@
 """Modules for script utilities.
 
-The top-level package surfaces the high-frequency console output helpers.
-Everything else lives in its submodule (e.g. `nclutils.fs`,
-`nclutils.strings`) and must be imported from there.
+Each public module lives in its own submodule and must be imported from
+there (e.g. `from nclutils import pp`, `from nclutils.fs import copy_file`,
+`from nclutils.strings import random_string`).
 """
 
-from .pretty_print import (
-    THEME,
-    Emitter,
-    Level,
-    LogLevel,
-    Theme,
-    Verbosity,
-    configure,
-    console,
-    critical,
-    debug,
-    dryrun,
-    err_console,
-    error,
-    get_default,
-    header,
-    info,
-    set_default,
-    step,
-    success,
-    trace,
-    warning,
-)
+from . import pp
 
-__all__ = [
-    "THEME",
-    "Emitter",
-    "Level",
-    "LogLevel",
-    "Theme",
-    "Verbosity",
-    "configure",
-    "console",
-    "critical",
-    "debug",
-    "dryrun",
-    "err_console",
-    "error",
-    "get_default",
-    "header",
-    "info",
-    "set_default",
-    "step",
-    "success",
-    "trace",
-    "warning",
-]
+__all__ = ["pp"]

--- a/src/nclutils/pp/__init__.py
+++ b/src/nclutils/pp/__init__.py
@@ -1,4 +1,4 @@
-"""nclutils.pretty_print is a tool for console output and logging."""
+"""nclutils.pp is a tool for console output and logging."""
 
 from .constants import LogLevel, Verbosity
 from .emitter import (

--- a/src/nclutils/pp/_logsink.py
+++ b/src/nclutils/pp/_logsink.py
@@ -1,7 +1,7 @@
-"""Private file-logging substrate for nclutils.pretty_print.
+"""Private file-logging substrate for nclutils.pp.
 
 Each `Emitter` constructs one `_LogSink`. The sink owns a stdlib
-`logging.Logger` (named `nclutils.pretty_print._{id(emitter)}`, with `propagate=False`)
+`logging.Logger` (named `nclutils.pp._{id(emitter)}`, with `propagate=False`)
 plus a single `FileHandler` opened lazily on first emit. Console
 rendering and file rendering are independent - the file ignores
 `quiet`/`verbosity`, the console ignores `loglevel`.
@@ -223,7 +223,7 @@ class _LogSink:
         if self._logfile is None:  # pragma: no cover
             msg = "_ensure_logger called with no logfile; this is a bug"
             raise RuntimeError(msg)
-        name = f"nclutils.pretty_print._{id(self)}"
+        name = f"nclutils.pp._{id(self)}"
         logger = logging.getLogger(name)
         # Close and remove any stale handlers from a prior instance that shared
         # this logger name via id() reuse - avoids ResourceWarning on GC.

--- a/src/nclutils/pp/constants.py
+++ b/src/nclutils/pp/constants.py
@@ -1,4 +1,4 @@
-"""Constants for the nclutils.pretty_print package."""
+"""Constants for the nclutils.pp package."""
 
 from enum import IntEnum
 
@@ -16,10 +16,10 @@ class LogLevel(IntEnum):
 
     Use as the `loglevel=` kwarg on `Emitter` / `configure()` to set the
     minimum severity that gets written to the configured logfile. The
-    numerics match stdlib `logging` (`DEBUG=10`, `INFO=20`, …) so nclutils.pretty_print's
+    numerics match stdlib `logging` (`DEBUG=10`, `INFO=20`, …) so nclutils.pp's
     file substrate composes cleanly with stdlib tooling. `TRACE=5` is
-    nclutils.pretty_print-specific and is registered with `logging.addLevelName` at
-    import time of `nclutils.pretty_print._logsink`.
+    nclutils.pp-specific and is registered with `logging.addLevelName` at
+    import time of `nclutils.pp._logsink`.
     """
 
     TRACE = 5

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -1,4 +1,4 @@
-"""Emitter class and module-level API for pretty_print2's console output.
+"""Emitter class and module-level API for nclutils.pp's console output.
 
 Construct an `Emitter` directly when you need isolated configuration - typically
 in tests or when a library wants to coexist with a host CLI's output settings.
@@ -69,7 +69,7 @@ THEME = RichTheme(
 class Level:
     """Per-level theme override.
 
-    Any field left as None inherits nclutils.pretty_print's built-in default. `marker=""` is
+    Any field left as None inherits nclutils.pp's built-in default. `marker=""` is
     a real value meaning "no marker"; only `None` falls back to the default.
     """
 
@@ -80,7 +80,7 @@ class Level:
 
 @dataclass(frozen=True, slots=True)
 class Theme:
-    """Per-level overrides for nclutils.pretty_print output.
+    """Per-level overrides for nclutils.pp output.
 
     Any level field left as None keeps that level's defaults entirely.
     Successive `configure(theme=...)` calls accumulate at the field level -
@@ -1026,7 +1026,7 @@ def configure(  # noqa: PLR0913
 
     Only fields explicitly passed are updated; omitted kwargs leave the
     existing value untouched. Call after parsing CLI flags to wire `-v`,
-    `--quiet`, etc. into nclutils.pretty_print's output. Theme overrides accumulate at
+    `--quiet`, etc. into nclutils.pp's output. Theme overrides accumulate at
     the field level across successive calls.
     """
     _default.configure(

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -5,13 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from nclutils import console
 from nclutils.fs import (
     clean_directory,
     directory_tree,
     find_files,
     find_subdirectories,
 )
+from nclutils.pp import console
 
 
 def test_fetch_subdirectories_basic(temp_directory: Path) -> None:

--- a/tests/pp/__init__.py
+++ b/tests/pp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the pp module."""

--- a/tests/pp/conftest.py
+++ b/tests/pp/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for nclutils.pretty_print tests."""
+"""Shared fixtures for nclutils.pp tests."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 from rich.console import Console
 
-from nclutils.pretty_print.emitter import (
+from nclutils.pp.emitter import (
     Emitter,
     LogLevel,
     Theme,

--- a/tests/pp/test_emitter.py
+++ b/tests/pp/test_emitter.py
@@ -10,7 +10,7 @@ from rich.json import JSON
 from rich.pretty import Pretty
 from rich.text import Text
 
-from nclutils.pretty_print.emitter import Emitter, Level, LogLevel, Theme, Verbosity
+from nclutils.pp.emitter import Emitter, Level, LogLevel, Theme, Verbosity
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/pp/test_logfile.py
+++ b/tests/pp/test_logfile.py
@@ -11,15 +11,15 @@ import pytest
 from rich.json import JSON
 from rich.text import Text
 
-from nclutils.pretty_print._logsink import _LogSink
-from nclutils.pretty_print.emitter import Emitter, LogLevel, Verbosity
+from nclutils.pp._logsink import _LogSink
+from nclutils.pp.emitter import Emitter, LogLevel, Verbosity
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
 class TestLogSinkModule:
-    """`nclutils.pretty_print._logsink` registers TRACE at import and exposes _LogSink."""
+    """`nclutils.pp._logsink` registers TRACE at import and exposes _LogSink."""
 
     def test_trace_level_name_registered(self) -> None:
         """Verify importing _logsink registers level 5 as 'TRACE' with stdlib logging."""

--- a/tests/pp/test_module_api.py
+++ b/tests/pp/test_module_api.py
@@ -1,4 +1,4 @@
-"""Tests for nclutils.pretty_print's module-level API surface.
+"""Tests for nclutils.pp's module-level API surface.
 
 Covers the module-level wrapper functions (`info`, `success`, `step`, etc.),
 default-emitter management (`get_default` / `set_default`), and package-level
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING
 import pytest
 from rich.console import Console
 
-from nclutils.pretty_print import Emitter, Level, Theme, Verbosity, get_default, set_default
-from nclutils.pretty_print import emitter as emitter_module
+from nclutils.pp import Emitter, Level, Theme, Verbosity, get_default, set_default
+from nclutils.pp import emitter as emitter_module
 
 if TYPE_CHECKING:
     from .conftest import RecordingEmitterFactory
@@ -106,7 +106,7 @@ class TestModuleWrapperPerCallOverrides:
     def test_module_info_accepts_style_kwarg_without_collision(
         self, isolated_default: None, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify nclutils.pretty_print.info(message, style=...) works through the module-level wrapper."""
+        """Verify nclutils.pp.info(message, style=...) works through the module-level wrapper."""
         # Given a default emitter wired to a recording stdout
         e, out, _ = make_recording_emitter()
         set_default(e)

--- a/tests/pp/test_theme.py
+++ b/tests/pp/test_theme.py
@@ -1,4 +1,4 @@
-"""Tests for nclutils.pretty_print's theme customization API.
+"""Tests for nclutils.pp's theme customization API.
 
 Covers the `Level` and `Theme` dataclasses, `_merge_theme` field-merge
 semantics, `Emitter._resolve` overlay resolution, and the rendered output of
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from nclutils.pretty_print.emitter import Emitter, Level, Theme, _merge_theme
+from nclutils.pp.emitter import Emitter, Level, Theme, _merge_theme
 
 if TYPE_CHECKING:
     from .conftest import RecordingEmitterFactory

--- a/tests/pretty_print/__init__.py
+++ b/tests/pretty_print/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for the pretty_print module."""


### PR DESCRIPTION
## Summary

- Renames `nclutils.pretty_print` to `nclutils.pp` and drops the package-root re-exports of its symbols.
- Preferred call style is `from nclutils import pp` then `pp.info(...)`, `pp.success(...)`, etc. Direct imports `from nclutils.pp import info` also work.
- Updates README, `docs/pp.md` (renamed from `docs/pretty_print.md`), `docs/fs.md`, `docs/shell_commands.md`, and `CLAUDE.md` to reflect the new convention. Internal stdlib logger names move from `nclutils.pretty_print.*` to `nclutils.pp.*`.

## Why

`pretty_print` was the only module re-exported at the package root. Folding it into the standard "import from submodule" convention removes a special case, makes call sites self-documenting (`pp.info` vs. bare `info`), and eliminates collision risk with stdlib `logging` names and local variables.

## Breaking change

`from nclutils import info, success, ...` and similar root-level imports no longer work. Migration:

| Before                               | After                                        |
| ------------------------------------ | -------------------------------------------- |
| `from nclutils import info`          | `from nclutils import pp` then `pp.info(...)` |
| `from nclutils import info, success` | `from nclutils.pp import info, success`      |

## Test plan

- [x] `uv run pytest` — 323/323 passing
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy --config-file=pyproject.toml src/` — clean
- [x] Smoke test both import styles work end-to-end