### PR TITLE
feat(pp): render level details with tree connectors

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -77,7 +77,7 @@ jobs:
                   changelog: CHANGELOG.md
 
             - name: Create Release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3
               with:
                   body: ${{join(fromJson(steps.generate_notes.outputs.notes).notes, '')}}
                   files: |
@@ -88,7 +88,7 @@ jobs:
 
     publish-to-pypi:
         runs-on: ubuntu-latest
-        needs: [run-tests, autorelease]
+        needs: [ run-tests, autorelease ]
         env:
             TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
             TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,6 @@ default_install_hook_types: [commit-msg, pre-commit, pre-push]
 default_stages: [pre-commit, manual]
 fail_fast: true
 repos:
-  - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.15.1
-    hooks:
-      - id: commitizen
-        stages: [pre-push]
-        pass_filenames: false
-        always_run: true
-
   - repo: "https://github.com/pre-commit/pygrep-hooks"
     rev: v1.10.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,14 @@
 ---
 # https://pre-commit.com
-default_install_hook_types: [ commit-msg, pre-commit, pre-push ]
-default_stages: [ pre-commit, manual ]
+default_install_hook_types: [commit-msg, pre-commit, pre-push]
+default_stages: [pre-commit, manual]
 fail_fast: true
 repos:
-  - repo: "https://github.com/commitizen-tools/commitizen"
+  - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.15.1
     hooks:
       - id: commitizen
-        stages:
-          - pre-push
+        stages: [pre-push]
 
   - repo: "https://github.com/pre-commit/pygrep-hooks"
     rev: v1.10.0
@@ -48,10 +47,10 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: trailing-whitespace
-        types: [ python ]
-        args: [ --markdown-linebreak-ext=md ]
+        types: [python]
+        args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
-        types: [ python ]
+        types: [python]
 
   - repo: "https://github.com/gitleaks/gitleaks"
     rev: v8.30.1
@@ -63,21 +62,21 @@ repos:
     hooks:
       - id: ruff-check
         exclude: tests/
-        args: [ --no-fix ]
+        args: [--no-fix]
       - id: ruff-format
-        args: [ --check ]
+        args: [--check]
 
   - repo: "https://github.com/adhtruong/mirrors-typos"
     rev: v1.46.0
     hooks:
       - id: typos
-        stages: [ commit-msg, pre-commit ]
+        stages: [commit-msg, pre-commit]
 
   - repo: "https://github.com/crate-ci/committed"
     rev: v1.1.11
     hooks:
       - id: committed
-        stages: [ commit-msg ]
+        stages: [commit-msg]
 
   - repo: local
     hooks:
@@ -85,7 +84,7 @@ repos:
         name: shellcheck
         entry: shellcheck --check-sourced --severity=warning
         language: system
-        types: [ shell ]
+        types: [shell]
 
       - id: mypy
         name: mypy
@@ -93,7 +92,7 @@ repos:
         exclude: "tests/|duties.py"
         pass_filenames: false
         language: system
-        types: [ python ]
+        types: [python]
 
       - id: pytest
         name: pytest
@@ -107,3 +106,17 @@ repos:
           uv\.lock|
           pyproject\.toml
           )
+
+      # Workaround until commitizen fixes its commitizen-branch hook (see commitizen #1923).
+      # The upstream hook's args contain the literal "$PRE_COMMIT_FROM_REF..$PRE_COMMIT_TO_REF",
+      # but no client (pre-commit, prek) substitutes those placeholders, and `cz check` doesn't
+      # expand them either, so git receives them verbatim and fails with "ambiguous argument".
+      # Wrapping the call in `bash -c` forces the shell to expand the env vars prek/pre-commit
+      # do set. Remove this block once commitizen ships a fix upstream.
+      - id: commitizen-branch
+        name: commitizen check branch
+        entry: bash -c 'uv run --quiet cz check --rev-range "$PRE_COMMIT_FROM_REF..$PRE_COMMIT_TO_REF"' --
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
     hooks:
       - id: commitizen
         stages: [pre-push]
+        pass_filenames: false
+        always_run: true
 
   - repo: "https://github.com/pre-commit/pygrep-hooks"
     rev: v1.10.0

--- a/docs/pp.md
+++ b/docs/pp.md
@@ -41,7 +41,29 @@ The `pp.step()` block shows a live spinner with sub-items beneath it. On success
 
 ## Output levels
 
-Every level routes through the same shape: `pp.func(message, details=[...])`. `details` is optional. String items render as indented continuation lines in a dimmer shade; Rich markup is escaped by default so user-supplied strings can't inject styling. Non-strings are auto-rendered with Rich (dicts, dataclasses, and arbitrary objects via `Pretty`; `JSON` / `Syntax` / `Table` pass through unchanged).
+Every level routes through the same shape: `pp.func(message, details=[...])`. `details` is optional. Items render as a tree beneath the message. Non-final items are prefixed with `├─` and the final item with `└─`, matching `pp.step()`'s sub-item layout. Multi-line renderables (Tables, JSON, multi-line `Pretty` outputs) get a `│ ` continuation pipe under non-final positions and a blank gutter under the final position. String items are colored with the level's `detail_style`; Rich markup is escaped by default so user-supplied strings can't inject styling. Non-strings are auto-rendered with Rich (dicts, dataclasses, and arbitrary objects via `Pretty`; `JSON` / `Syntax` / `Table` pass through unchanged).
+
+For example, this call:
+
+```python
+from nclutils import pp
+
+pp.success("deployed", details=["build #1742", "rollout 100%", "duration: 3.2s"])
+```
+
+renders as:
+
+```text
+✓ deployed
+  ├─ build #1742
+  ├─ rollout 100%
+  └─ duration: 3.2s
+```
+
+The `├─` and `└─` glyphs are styled via the `sub.pipe` theme key (the same key `pp.step()` uses for its sub-item connectors), so retuning that one entry restyles every tree connector across the API.
+
+> [!NOTE]
+> Tree connectors appear in stdout/stderr only. Logfile records (configured via `pp.configure(logfile=...)`) format details using the logfmt's `%(detail)s` field; they do not contain `├─`, `└─`, or `│` characters.
 
 Pass `markup=True` to opt into Rich markup parsing for `message` and any string `details` items in that call:
 

--- a/docs/pp.md
+++ b/docs/pp.md
@@ -63,7 +63,7 @@ renders as:
 The `├─` and `└─` glyphs are styled via the `sub.pipe` theme key (the same key `pp.step()` uses for its sub-item connectors), so retuning that one entry restyles every tree connector across the API.
 
 > [!NOTE]
-> Tree connectors appear in stdout/stderr only. Logfile records (configured via `pp.configure(logfile=...)`) format details using the logfmt's `%(detail)s` field; they do not contain `├─`, `└─`, or `│` characters.
+> Tree connectors appear in stdout/stderr only. In logfile records, each detail item becomes its own log record at the parent's severity with the detail text in the standard `%(message)s` field, prefixed by two spaces; the file does not contain `├─`, `└─`, or `│` characters.
 
 Pass `markup=True` to opt into Rich markup parsing for `message` and any string `details` items in that call:
 
@@ -255,7 +255,7 @@ To fully reset, build a fresh emitter: `pp.set_default(pp.Emitter())`.
 
 ### What's not themed
 
-The horizontal rule under `pp.header()`, the connector glyphs beneath `pp.step()` (`├─`, `└─`), and the `[dry-run]` tag are not customizable.
+The horizontal rule under `pp.header()` and the `[dry-run]` tag are not customizable. The `├─`/`└─` connector glyphs beneath `pp.step()` and `details` lists share the `sub.pipe` Rich theme entry on the underlying console (defaulting to `bright_black`); the glyph characters themselves are fixed, and the `pp.Theme` dataclass does not expose a field to retune their style. To override it, build a custom `Console(theme=...)` and pass it via `pp.Emitter(console=...)`.
 
 ## Reaching the underlying consoles
 

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -14,13 +14,13 @@ deburr("crème brûlée")              # "creme brulee"
 
 All five case helpers accept arbitrary text and tokenize it the same way: `list_words` splits on word boundaries, contractions are folded, and accents are stripped via `deburr` before joining.
 
-| Function          | Example input         | Output                       |
-| ----------------- | --------------------- | ---------------------------- |
-| `camel_case`      | `"FOO BAR_bAz"`       | `"fooBarBaz"`                |
-| `kebab_case`      | `"The b c_d-e!f"`     | `"the-b-c-d-e-f"`            |
-| `pascal_case`     | `"FOO BAR_bAz"`       | `"FooBarBaz"`                |
-| `separator_case`  | `"a!!b___c.d"` (`_`)  | `"a_b_c_d"`                  |
-| `snake_case`      | `"This is Snake!"`    | `"this_is_snake"`            |
+| Function         | Example input        | Output            |
+| ---------------- | -------------------- | ----------------- |
+| `camel_case`     | `"FOO BAR_bAz"`      | `"fooBarBaz"`     |
+| `kebab_case`     | `"The b c_d-e!f"`    | `"the-b-c-d-e-f"` |
+| `pascal_case`    | `"FOO BAR_bAz"`      | `"FooBarBaz"`     |
+| `separator_case` | `"a!!b___c.d"` (`_`) | `"a_b_c_d"`       |
+| `snake_case`     | `"This is Snake!"`   | `"this_is_snake"` |
 
 `separator_case` takes a second argument, the joiner character, and defaults to `-`. Use it when you want a separator other than `_` or `-` without writing your own join.
 

--- a/scripts/pp_demo.py
+++ b/scripts/pp_demo.py
@@ -1,0 +1,159 @@
+# ruff: noqa: INP001
+"""Demonstrate every output style nclutils.pp provides.
+
+Developer-only tool. Not part of the public API and not exported as a
+console entrypoint. Run from the repository root:
+
+    uv run scripts/pp_demo.py
+
+The script prints every visual section pp can produce, in order, so
+maintainers can spot visual regressions after changes to the module.
+"""
+
+from __future__ import annotations
+
+from nclutils import pp
+from nclutils.pp import Emitter, Level, Theme, Verbosity
+
+
+def _section(title: str) -> None:
+    """Print a left-aligned section header rule."""
+    pp.header(title, align="left")
+
+
+def _levels() -> None:
+    """Print one line at every built-in level."""
+    _section("Levels")
+    pp.info("info: informational message")
+    pp.success("success: operation completed")
+    pp.warning("warning: something to watch")
+    pp.error("error: operation failed")
+    pp.critical("critical: system on fire")
+    pp.debug("debug: only at -v")
+    pp.trace("trace: only at -vv")
+    pp.dryrun("dryrun: would have happened")
+
+
+def _headers() -> None:
+    """Print headers with each alignment plus a bare rule."""
+    _section("Headers")
+    pp.header("centered title")
+    pp.header("left title", align="left")
+    pp.header("right title", align="right")
+    pp.header()
+
+
+def _steps() -> None:
+    """Demonstrate the success, failure, and ephemeral step paths."""
+    _section("Steps")
+
+    with pp.step("success path") as s:
+        s.sub("first sub-item")
+        s.sub("second sub-item")
+
+    try:
+        with pp.step("failure path") as s:
+            s.sub("attempted this")
+            msg = "boom"
+            raise RuntimeError(msg)  # noqa: TRY301
+    except RuntimeError:
+        pass
+
+    with pp.step("ephemeral path", ephemeral=True) as s:
+        s.sub("disappears on success")
+
+
+def _details_simple() -> None:
+    """Demonstrate details with tree connectors: single, multiple, and markup."""
+    _section("Details (tree connectors)")
+    pp.info("one detail", details=["only-item"])
+    pp.success("multiple details", details=["first", "second", "third"])
+    pp.warning(
+        "with markup",
+        details=["[underline]parsed[/] markup"],
+        markup=True,
+    )
+
+
+def _details_multiline() -> None:
+    """Demonstrate `│` continuation under non-final and blank gutter under final."""
+    _section("Multi-line details")
+    pp.info(
+        "multi-line string in non-final position",
+        details=["line one\nline two\nline three", "trailing item"],
+    )
+    pp.info(
+        "dict in final position",
+        details=["leading", {"status": 200, "items": [1, 2, 3], "meta": {"x": "y"}}],
+    )
+
+
+def _per_call_overrides() -> None:
+    """Demonstrate per-call style, marker, and detail_style overrides."""
+    _section("Per-call overrides")
+    pp.info("custom marker", marker="→ ", details=["one"])
+    pp.info(
+        "custom style",
+        style="bold magenta",
+        detail_style="magenta",
+        details=["styled"],
+    )
+    pp.info("no marker (suppressed)", marker="", details=["bare"])
+
+
+def _theme_override() -> None:
+    """Demonstrate a custom Theme via a dedicated Emitter."""
+    _section("Theme override")
+    e = Emitter(
+        verbosity=Verbosity.TRACE,
+        theme=Theme(
+            info=Level(style="bold cyan", detail_style="cyan", marker="ℹ "),  # noqa: RUF001
+            success=Level(marker="✔ "),
+        ),
+    )
+    e.info("info via custom Theme", details=["one", "two"])
+    e.success("success via custom Theme")
+
+
+def _verbosity_matrix() -> None:
+    """Show what's visible at each verbosity setting and under quiet."""
+    _section("Verbosity/quiet matrix")
+
+    e_info = Emitter(verbosity=Verbosity.INFO)
+    e_info.info("INFO emitter: debug and trace are suppressed")
+    e_info.debug("you should NOT see this debug line")
+    e_info.trace("you should NOT see this trace line")
+
+    e_debug = Emitter(verbosity=Verbosity.DEBUG)
+    e_debug.info("DEBUG emitter: debug visible, trace still suppressed")
+    e_debug.debug("debug visible")
+    e_debug.trace("you should NOT see this trace line")
+
+    e_trace = Emitter(verbosity=Verbosity.TRACE)
+    e_trace.info("TRACE emitter: debug and trace both visible")
+    e_trace.debug("debug visible")
+    e_trace.trace("trace visible")
+
+    e_quiet = Emitter(quiet=True)
+    e_quiet.info("you should NOT see this (info silenced under quiet)")
+    e_quiet.success("you should NOT see this (success silenced under quiet)")
+    e_quiet.warning("warnings still appear under quiet")
+    e_quiet.dryrun("dryrun bypasses quiet")
+    e_quiet.error("errors always appear")
+
+
+def main() -> None:
+    """Run every demo section in order."""
+    pp.configure(verbosity=Verbosity.TRACE)
+    _levels()
+    _headers()
+    _steps()
+    _details_simple()
+    _details_multiline()
+    _per_call_overrides()
+    _theme_override()
+    _verbosity_matrix()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pp_demo.py
+++ b/scripts/pp_demo.py
@@ -16,14 +16,9 @@ from nclutils import pp
 from nclutils.pp import Emitter, Level, Theme, Verbosity
 
 
-def _section(title: str) -> None:
-    """Print a left-aligned section header rule."""
-    pp.header(title, align="left")
-
-
 def _levels() -> None:
     """Print one line at every built-in level."""
-    _section("Levels")
+    pp.header("Levels", align="left")
     pp.info("info: informational message")
     pp.success("success: operation completed")
     pp.warning("warning: something to watch")
@@ -36,7 +31,7 @@ def _levels() -> None:
 
 def _headers() -> None:
     """Print headers with each alignment plus a bare rule."""
-    _section("Headers")
+    pp.header("Headers", align="left")
     pp.header("centered title")
     pp.header("left title", align="left")
     pp.header("right title", align="right")
@@ -45,7 +40,7 @@ def _headers() -> None:
 
 def _steps() -> None:
     """Demonstrate the success, failure, and ephemeral step paths."""
-    _section("Steps")
+    pp.header("Steps", align="left")
 
     with pp.step("success path") as s:
         s.sub("first sub-item")
@@ -55,7 +50,7 @@ def _steps() -> None:
         with pp.step("failure path") as s:
             s.sub("attempted this")
             msg = "boom"
-            raise RuntimeError(msg)  # noqa: TRY301
+            raise RuntimeError(msg)  # noqa: TRY301 -- intentional, exercises step() failure branch
     except RuntimeError:
         pass
 
@@ -65,7 +60,7 @@ def _steps() -> None:
 
 def _details_simple() -> None:
     """Demonstrate details with tree connectors: single, multiple, and markup."""
-    _section("Details (tree connectors)")
+    pp.header("Details (tree connectors)", align="left")
     pp.info("one detail", details=["only-item"])
     pp.success("multiple details", details=["first", "second", "third"])
     pp.warning(
@@ -77,7 +72,7 @@ def _details_simple() -> None:
 
 def _details_multiline() -> None:
     """Demonstrate `│` continuation under non-final and blank gutter under final."""
-    _section("Multi-line details")
+    pp.header("Multi-line details", align="left")
     pp.info(
         "multi-line string in non-final position",
         details=["line one\nline two\nline three", "trailing item"],
@@ -90,7 +85,7 @@ def _details_multiline() -> None:
 
 def _per_call_overrides() -> None:
     """Demonstrate per-call style, marker, and detail_style overrides."""
-    _section("Per-call overrides")
+    pp.header("Per-call overrides", align="left")
     pp.info("custom marker", marker="→ ", details=["one"])
     pp.info(
         "custom style",
@@ -103,7 +98,7 @@ def _per_call_overrides() -> None:
 
 def _theme_override() -> None:
     """Demonstrate a custom Theme via a dedicated Emitter."""
-    _section("Theme override")
+    pp.header("Theme override", align="left")
     e = Emitter(
         verbosity=Verbosity.TRACE,
         theme=Theme(
@@ -117,7 +112,7 @@ def _theme_override() -> None:
 
 def _verbosity_matrix() -> None:
     """Show what's visible at each verbosity setting and under quiet."""
-    _section("Verbosity/quiet matrix")
+    pp.header("Verbosity/quiet matrix", align="left")
 
     e_info = Emitter(verbosity=Verbosity.INFO)
     e_info.info("INFO emitter: debug and trace are suppressed")

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -247,8 +247,9 @@ def _print_level(  # noqa: PLR0913
             renderable.
         markup: When True, Rich markup in `message` and any string item in
             `details` is parsed instead of escaped.
-        details: Optional follow-up items, all indented to the same
-            2-space column. Strings are escaped (or parsed when `markup=True`)
+        details: Optional follow-up items, rendered as a tree beneath the
+            message with `├─` prefixed on non-final items and `└─` on the
+            final item. Strings are escaped (or parsed when `markup=True`)
             and rendered with `detail_style`. Rich renderables (e.g. `JSON`,
             `Syntax`, `Table`) pass through and render with their own
             coloring. Any other Python object is wrapped in `Pretty()` so

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Any
 from rich.console import Console
 from rich.live import Live
 from rich.markup import escape
-from rich.padding import Padding
 from rich.pretty import Pretty
 from rich.protocol import is_renderable
 from rich.spinner import Spinner
@@ -284,20 +283,10 @@ def _print_level(  # noqa: PLR0913
         target.print(message, **kwargs)
 
     if details:
-        # is_renderable(str) is True, so the str branch must come first to keep
-        # markup escaping and detail_style intact for plain strings.
-        for item in details:
-            if isinstance(item, str):
-                detail_text = item if markup else escape(item)
-                rendered = Text.from_markup(f"[{detail_style}]{detail_text}[/]")
-            elif is_renderable(item):
-                rendered = item
-            else:
-                # detail_style intentionally not applied - Pretty has its own
-                # syntax-aware highlighting and layering markup over it would
-                # clobber number/key/string colors.
-                rendered = Pretty(item)  # type: ignore[assignment]
-            target.print(Padding.indent(rendered, 2), **kwargs)
+        target.print(
+            _DetailTree(details, detail_style=detail_style, markup=markup),
+            **kwargs,
+        )
 
 
 class Step:
@@ -357,6 +346,51 @@ class Step:
             line = Text.from_markup(f"  [sub.pipe]{connector}[/] ")
             line.append_text(sub_text)
             yield line
+
+
+class _DetailTree:
+    """Render a `details` list with tree connectors prefixed on every line.
+
+    Wrap each item (str -> escaped+styled Text, Rich renderable -> as-is,
+    other -> Pretty) and prefix every rendered line with the appropriate
+    tree glyph: `├─` for non-final items, `└─` for the final item, `│ `
+    for continuation lines under a non-final item, two spaces under the
+    final item.
+
+    The connector glyphs use the `sub.pipe` theme key, matching `Step.sub()`
+    so theme retuning happens in one place.
+    """
+
+    def __init__(self, items: list[Any], *, detail_style: str, markup: bool) -> None:
+        self._items = items
+        self._detail_style = detail_style
+        self._markup = markup
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        last = len(self._items) - 1
+        for i, item in enumerate(self._items):
+            is_last = i == last
+            head = "└─" if is_last else "├─"
+            cont = "  " if is_last else "│ "
+
+            rendered = self._wrap(item)
+            sub_options = options.update(width=max(1, options.max_width - 5))
+            for line_idx, segments in enumerate(console.render_lines(rendered, sub_options)):
+                line = Text("  ")
+                line.append(head if line_idx == 0 else cont, style="sub.pipe")
+                line.append(" ")
+                for seg in segments:
+                    if seg.text:
+                        line.append(seg.text, style=seg.style if seg.style is not None else "")
+                yield line
+
+    def _wrap(self, item: Any) -> RenderableType:
+        if isinstance(item, str):
+            text = item if self._markup else escape(item)
+            return Text.from_markup(f"[{self._detail_style}]{text}[/]")
+        if is_renderable(item):
+            return item
+        return Pretty(item)
 
 
 class Emitter:

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -369,13 +369,14 @@ class _DetailTree:
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
         last = len(self._items) - 1
+        # 5 = 2 leading spaces + 2-cell glyph (├─/└─/│ ) + 1 trailing space
+        sub_options = options.update(width=max(1, options.max_width - 5))
         for i, item in enumerate(self._items):
             is_last = i == last
             head = "└─" if is_last else "├─"
             cont = "  " if is_last else "│ "
 
             rendered = self._wrap(item)
-            sub_options = options.update(width=max(1, options.max_width - 5))
             for line_idx, segments in enumerate(console.render_lines(rendered, sub_options)):
                 line = Text("  ")
                 line.append(head if line_idx == 0 else cont, style="sub.pipe")

--- a/tests/pp/test_emitter.py
+++ b/tests/pp/test_emitter.py
@@ -1065,7 +1065,7 @@ class TestDetailTree:
     def test_markup_true_still_parses_string_details(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify markup=True parses Rich markup inside string details when multiple details are present."""
+        """Verify markup=True parses Rich markup inside string details."""
         # Given an Emitter wired to a recording stdout
         e, out, _ = make_recording_emitter()
 

--- a/tests/pp/test_emitter.py
+++ b/tests/pp/test_emitter.py
@@ -8,6 +8,7 @@ import pytest
 from rich.console import Console
 from rich.json import JSON
 from rich.pretty import Pretty
+from rich.table import Table
 from rich.text import Text
 
 from nclutils.pp.emitter import Emitter, Level, LogLevel, Theme, Verbosity
@@ -394,7 +395,7 @@ class TestPrettyDetails:
     def test_mixed_details_all_indent_to_same_column(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify str, dict, and Rich renderable details all indent uniformly."""
+        """Verify str, dict, and Rich renderable details all share the 2-space indent and the tree glyphs."""
         # Given an Emitter at TRACE verbosity wired to a recording stdout
         e, out, _ = make_recording_emitter(verbosity=Verbosity.TRACE)
 
@@ -404,13 +405,18 @@ class TestPrettyDetails:
             details=["plain string", {"k": "v"}, JSON('{"x": 2}')],
         )
 
-        # Then every non-empty content line below the header begins with the
-        # 2-space indent supplied by Padding.indent
-        lines = out.export_text().splitlines()
+        # Then every non-empty content line below the header begins with two
+        # spaces of indent (the 2-col gutter the connector/continuation share)
+        joined = out.export_text()
+        lines = joined.splitlines()
         content_lines = [ln for ln in lines[1:] if ln.strip()]
         assert content_lines, "expected at least one detail line"
         for ln in content_lines:
             assert ln.startswith("  "), f"detail line not indented: {ln!r}"
+
+        # And the first item gets `├─`, the last gets `└─`
+        assert "├─ plain string" in joined
+        assert "└─" in joined
 
 
 class TestCriticalLevel:
@@ -945,3 +951,150 @@ class TestSubMarkup:
 
         # Then the underline styling appears in the rendered output
         assert "underline" in out.export_html(inline_styles=True)
+
+
+class TestDetailTree:
+    """`details` render with `├─` / `└─` / `│` connectors on stdout/stderr."""
+
+    def test_multiple_string_details_use_branch_and_last_glyphs(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify non-final details render with `├─` and the final renders with `└─`."""
+        # Given an Emitter wired to a recording stdout
+        e, out, _ = make_recording_emitter()
+
+        # When info is emitted with three string details
+        e.info("hello", details=["one", "two", "three"])
+
+        # Then the rendered text contains both branch and last connectors
+        text = out.export_text()
+        assert "├─ one" in text
+        assert "├─ two" in text
+        assert "└─ three" in text
+        assert "├─ three" not in text
+
+    def test_single_detail_uses_only_last_glyph(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify a single detail item renders only `└─`, never `├─`."""
+        # Given an Emitter wired to a recording stdout
+        e, out, _ = make_recording_emitter()
+
+        # When success is emitted with one detail
+        e.success("ok", details=["only-item"])
+
+        # Then `└─` appears and `├─` does not
+        text = out.export_text()
+        assert "└─ only-item" in text
+        assert "├─" not in text
+
+    @pytest.mark.parametrize(
+        ("level_method", "stream", "verbosity"),
+        [
+            ("info", "stdout", Verbosity.INFO),
+            ("success", "stdout", Verbosity.INFO),
+            ("dryrun", "stdout", Verbosity.INFO),
+            ("debug", "stdout", Verbosity.DEBUG),
+            ("trace", "stdout", Verbosity.TRACE),
+            ("warning", "stderr", Verbosity.INFO),
+            ("error", "stderr", Verbosity.INFO),
+            ("critical", "stderr", Verbosity.INFO),
+        ],
+    )
+    def test_all_level_methods_render_connectors(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        level_method: str,
+        stream: str,
+        verbosity: Verbosity,
+    ) -> None:
+        """Verify every level method renders details with tree connectors."""
+        # Given an Emitter at the verbosity needed for this level
+        e, out, err = make_recording_emitter(verbosity=verbosity)
+        target = out if stream == "stdout" else err
+
+        # When the level method is invoked with two details
+        getattr(e, level_method)("msg", details=["a", "b"])
+
+        # Then both branch and last connectors appear on the right stream
+        text = target.export_text()
+        assert "├─ a" in text
+        assert "└─ b" in text
+
+    def test_multiline_renderable_gets_continuation_pipe(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify a multi-line renderable in a non-final position gets `│` continuation lines."""
+        # Given an Emitter wired to a recording stdout and a multi-line Table
+        e, out, _ = make_recording_emitter()
+        table = Table(show_header=False, box=None)
+        table.add_row("row-one")
+        table.add_row("row-two")
+
+        # When info is emitted with the table in a non-final position
+        e.info("hdr", details=[table, "tail"])
+
+        # Then a continuation-pipe line appears beneath the table's first row
+        text = out.export_text()
+        pipe_lines = [ln for ln in text.splitlines() if ln.startswith("  │")]
+        assert pipe_lines, "expected at least one continuation-pipe line"
+        assert "├─" in text
+        assert "└─ tail" in text
+
+    def test_multiline_renderable_in_final_position_uses_blank_continuation(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify a multi-line renderable as the final item has plain-space continuation, not `│`."""
+        # Given an Emitter wired to a recording stdout and a multi-line Table
+        e, out, _ = make_recording_emitter()
+        table = Table(show_header=False, box=None)
+        table.add_row("row-one")
+        table.add_row("row-two")
+
+        # When info is emitted with the table as the final detail
+        e.info("hdr", details=["head", table])
+
+        # Then `└─` precedes the table
+        text = out.export_text()
+        assert "├─ head" in text
+        assert "└─" in text
+
+        # And no `│` continuation appears anywhere in the output
+        assert "│" not in text
+
+    def test_markup_true_still_parses_string_details(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify markup=True parses Rich markup inside string details when multiple details are present."""
+        # Given an Emitter wired to a recording stdout
+        e, out, _ = make_recording_emitter()
+
+        # When info is emitted with markup=True and bracketed details
+        e.info("hi", details=["[bold]item[/]"], markup=True)
+
+        # Then the brackets are consumed (parsed) rather than rendered as text
+        text = out.export_text()
+        assert "item" in text
+        assert "[bold]" not in text
+        assert "└─ item" in text
+
+    @pytest.mark.parametrize("details", [None, []])
+    def test_no_details_emits_no_extra_lines(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        details: list[str] | None,
+    ) -> None:
+        """Verify None or empty details emit only the header line, no stray connectors."""
+        # Given an Emitter wired to a recording stdout
+        e, out, _ = make_recording_emitter()
+
+        # When info is emitted with no details
+        e.info("just header", details=details)
+
+        # Then no tree glyphs appear and the output is the single header line
+        text = out.export_text()
+        assert "├─" not in text
+        assert "└─" not in text
+        assert "│" not in text
+        non_empty_lines = [ln for ln in text.splitlines() if ln.strip()]
+        assert len(non_empty_lines) == 1

--- a/tests/pp/test_logfile.py
+++ b/tests/pp/test_logfile.py
@@ -17,6 +17,8 @@ from nclutils.pp.emitter import Emitter, LogLevel, Verbosity
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from .conftest import RecordingEmitterFactory
+
 
 class TestLogSinkModule:
     """`nclutils.pp._logsink` registers TRACE at import and exposes _LogSink."""
@@ -590,3 +592,33 @@ class TestLogfileAcceptsStringPaths:
         assert "first" in text
         assert "second" in text
         assert id(e._logsink._handler) == first_handler_id
+
+
+class TestLogfileTreeGlyphs:
+    """Tree connectors render to stdout/stderr only and never leak into the logfile."""
+
+    def test_logfile_does_not_contain_tree_glyphs(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify tree connectors live on stdout only and never leak into the logfile."""
+        # Given an Emitter wired to a logfile at TRACE level
+        logfile = tmp_path / "out.log"
+        e, _, _ = make_recording_emitter(
+            verbosity=Verbosity.TRACE,
+            logfile=logfile,
+            loglevel=LogLevel.TRACE,
+        )
+
+        # When several level methods emit with multiple details
+        e.info("hi", details=["a", "b", "c"])
+        e.error("boom", details=["x", "y"])
+
+        # Then the logfile contains the detail text but none of the tree glyphs
+        contents = logfile.read_text()
+        assert "a" in contents
+        assert "x" in contents
+        assert "├─" not in contents
+        assert "└─" not in contents
+        assert "│" not in contents


### PR DESCRIPTION
## Summary

- Render `details` lists across all `pp` level methods (info/success/warning/error/critical/debug/trace/dryrun) as a tree, matching `pp.step()`'s sub-item layout: `├─` for non-final items, `└─` for the final item, `│ ` continuation under non-final multi-line renderables, blank gutter under final.
- Logfile output is unchanged — connectors live only on stdout/stderr; each detail item is still its own log record at the parent's severity.
- Add `scripts/pp_demo.py`, a developer-only script that exercises every visual section pp can produce so maintainers can spot regressions visually.
- Drop a broken upstream `commitizen` pre-push hook that errored on push; the existing `commitizen-branch` local hook continues to validate commit messages.

## Test plan

- [ ] `uv run pytest` is green (339 tests, including 16 new tests for `_DetailTree` and a logfile-glyph regression guard).
- [ ] `uv run ruff check src/ tests/ scripts/` passes.
- [ ] `uv run mypy --config-file=pyproject.toml src/ scripts/` passes.
- [ ] `uv run pre-commit run --all-files` passes.
- [ ] `uv run scripts/pp_demo.py` exits 0; output contains `├─`, `└─`, and `│ ` glyphs in the Details and Multi-line details sections; no `should NOT see` lines leak from the verbosity matrix.
- [ ] Spot-check `docs/pp.md` renders correctly on GitHub (the new tree-style example block and the `> [!NOTE]` callout).