### PR TITLE
feat(pp): add tag and right_tag kwargs to level methods

### DIFF
--- a/docs/pp.md
+++ b/docs/pp.md
@@ -92,6 +92,35 @@ Use `markup=True` when _you_ control the string. When the message comes from arb
 
 `pp.critical` is severity-only and does not raise. Use it for "the world is broken" notices that warrant a more emphatic visual than `pp.error`.
 
+Every level method (`info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`) accepts the optional `tag=` and `right_tag=` kwargs documented in [Per-call tags](#per-call-tags) below.
+
+### Per-call tags
+
+Every level method accepts `tag=` and `right_tag=` for one-off metadata that doesn't warrant a theme change:
+
+```python
+pp.info("saved", tag="api", right_tag="200ms")
+pp.error("upload failed", tag="uploader")
+```
+
+Renders:
+
+```text
+[api] saved                                                            200ms
+[uploader] ✗ upload failed
+```
+
+`tag` is dim text rendered between the marker and the message. It is recorded inline in the logfile (`[api] saved`) so file consumers see the same metadata that appeared on the console.
+
+`right_tag` is dim text right-aligned to the console width on the first line only. It is **presentation-only** and is never written to the logfile.
+
+When `right_tag` is passed to `pp.debug` or `pp.trace`, the caller's value replaces the auto-elapsed `[+s.fffs]` marker on the console; the logfile still records the elapsed timing so the audit trail is preserved.
+
+`pp.dryrun` combines a caller-supplied `tag` with its built-in `[dry-run]` marker on both the console and the logfile, with the caller's tag rendered first (`[deploy] [dry-run] would push`).
+
+> [!NOTE]
+> The caller is responsible for Rich-markup-escaping any `[`, `]`, or other reserved characters in `tag` and `right_tag`. Pass plain ASCII tags or pre-escaped strings.
+
 You can pass Rich renderables in `details` to get syntax-aware output, which is especially useful at `debug` / `trace`:
 
 ```python
@@ -320,7 +349,7 @@ finally:
 
 Every name below is available on the `pp` namespace (`from nclutils import pp`) and from `nclutils.pp` directly (e.g. `from nclutils.pp import info`).
 
-- `info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`, `header`. Output functions.
+- `info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`, `header`. Output functions. Every level function accepts `tag=` and `right_tag=` kwargs - see [Per-call tags](#per-call-tags) above.
 - `step(message, *, ephemeral=False)`. Spinner context manager.
 - `configure(*, verbosity=None, quiet=None, console=None, err_console=None, theme=None, logfile=None, loglevel=None, logfmt=None)`. Partial update of the default emitter.
 - `Emitter`. Instantiate directly for isolated configuration.

--- a/scripts/pp_demo.py
+++ b/scripts/pp_demo.py
@@ -96,6 +96,19 @@ def _per_call_overrides() -> None:
     pp.info("no marker (suppressed)", marker="", details=["bare"])
 
 
+def _per_call_tags() -> None:
+    """Demonstrate per-call tag and right_tag kwargs."""
+    pp.header("Per-call tags", align="left")
+    pp.info("with left tag only", tag="api")
+    pp.info("with right tag only", right_tag="200ms")
+    pp.info("with both tags", tag="api", right_tag="200ms")
+    pp.success("operation done", tag="deploy", right_tag="3.2s")
+    pp.error("upload failed", tag="uploader")
+    pp.dryrun("would push image", tag="deploy")
+    pp.debug("custom right tag overrides elapsed", right_tag="db: 1.2s")
+    pp.debug("auto elapsed (default)")
+
+
 def _theme_override() -> None:
     """Demonstrate a custom Theme via a dedicated Emitter."""
     pp.header("Theme override", align="left")
@@ -146,6 +159,7 @@ def main() -> None:
     _details_simple()
     _details_multiline()
     _per_call_overrides()
+    _per_call_tags()
     _theme_override()
     _verbosity_matrix()
 

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -214,6 +214,17 @@ def _message_to_log_text(message: str | RenderableType, *, markup: bool) -> str:
     return _render_renderable_to_plain(message).rstrip("\n")
 
 
+def _apply_tag_to_logmsg(tag: str | None, message: str) -> str:
+    """Prepend `[tag] ` to a log message body when tag is set.
+
+    Keeps caller-supplied audit metadata visible in the logfile so grep over
+    file output finds the same labels the operator saw on the console.
+    """
+    if tag:
+        return f"[{tag}] {message}"
+    return message
+
+
 def _print_level(  # noqa: PLR0913
     target: Console,
     *,
@@ -542,7 +553,7 @@ class Emitter:
             self._log_t0 = time.monotonic()
         return f"\\[+{time.monotonic() - self._log_t0:.3f}s]"
 
-    def info(
+    def info(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -551,6 +562,8 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print info-level output to stdout. Suppressed when `quiet` is True.
@@ -570,10 +583,20 @@ class Emitter:
         this call only - useful for one-off emphasis without restyling the
         whole emitter. `marker=""` suppresses the marker for the call. The
         logfile record is unaffected; these are presentation-only.
+
+        `tag` adds a dim left-side metadata tag rendered between marker and
+        message (e.g. `[api] ✓ saved`). The tag is recorded inline in the
+        logfile message as `[tag] msg` so audit grep stays useful. The caller
+        is responsible for escaping any Rich markup characters in the tag.
+
+        `right_tag` adds a dim right-aligned metadata tag on the first line
+        only. It is presentation-only and is NOT recorded in the logfile. The
+        caller is responsible for escaping any Rich markup characters in the
+        tag.
         """
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["info"],
-            message=_message_to_log_text(message, markup=markup),
+            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
             details=details,
         )
         if self.quiet:
@@ -589,10 +612,12 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
+            tag=tag,
+            right_tag=right_tag,
             **kwargs,
         )
 
-    def success(
+    def success(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -601,6 +626,8 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print success-level output to stdout. Suppressed when `quiet` is True.
@@ -611,11 +638,11 @@ class Emitter:
         is wrapped in `Pretty()`.
 
         See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        semantics.
+        and `tag`/`right_tag` semantics.
         """
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["success"],
-            message=_message_to_log_text(message, markup=markup),
+            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
             details=details,
         )
         if self.quiet:
@@ -631,10 +658,12 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
+            tag=tag,
+            right_tag=right_tag,
             **kwargs,
         )
 
-    def debug(
+    def debug(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -643,6 +672,8 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print debug-level output to stdout. Shown with `-v` or higher.
@@ -652,13 +683,20 @@ class Emitter:
         is dropped from the console line when `message` is a non-Text
         renderable (still recorded in the logfile).
 
+        Pass `right_tag` to override the auto-elapsed marker on the console
+        for one call (e.g. `right_tag="db: 1.2s"`); the logfile still records
+        the auto-elapsed `[+s.fffs]` marker so the audit timeline is preserved.
+
         See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        semantics.
+        and `tag`/`right_tag` semantics.
         """
         elapsed = self._elapsed_tag()
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["debug"],
-            message=f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
+            message=_apply_tag_to_logmsg(
+                tag,
+                f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
+            ),
             details=details,
         )
         if self.verbosity < Verbosity.DEBUG:
@@ -674,11 +712,12 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
-            right_tag=elapsed,
+            tag=tag,
+            right_tag=right_tag if right_tag is not None else elapsed,
             **kwargs,
         )
 
-    def trace(
+    def trace(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -687,17 +726,27 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print trace-level output to stdout. Shown with `-vv`.
 
+        Pass `right_tag` to override the auto-elapsed marker on the console
+        for one call; the logfile still records the auto-elapsed `[+s.fffs]`
+        marker so the audit timeline is preserved.
+
         See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        semantics, and `Emitter.debug` for the right-aligned elapsed tag.
+        and `tag`/`right_tag` semantics, and `Emitter.debug` for the
+        right-aligned elapsed tag.
         """
         elapsed = self._elapsed_tag()
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["trace"],
-            message=f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
+            message=_apply_tag_to_logmsg(
+                tag,
+                f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
+            ),
             details=details,
         )
         if self.verbosity < Verbosity.TRACE:
@@ -713,11 +762,12 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
-            right_tag=elapsed,
+            tag=tag,
+            right_tag=right_tag if right_tag is not None else elapsed,
             **kwargs,
         )
 
-    def dryrun(
+    def dryrun(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -726,6 +776,8 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print a dry-run notice to stdout. Always shown, even when `quiet`.
@@ -733,19 +785,29 @@ class Emitter:
         Bypasses `quiet` because a dry-run notice describes an action that
         would otherwise have happened - silencing it defeats the purpose.
 
+        When `tag` is supplied, it renders before the existing `[dry-run]`
+        marker (e.g. `[deploy] [dry-run] would push`) on both the console
+        and in the logfile.
+
         See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        semantics.
+        and `tag`/`right_tag` semantics.
         """
-        # Include [dry-run] inline in the file message for grep-ability.
+        # Include [dry-run] inline in the file message for grep-ability, and
+        # prepend any caller-supplied tag so audit grep finds the same labels
+        # the operator saw on the console.
+        log_body = f"[dry-run] {_message_to_log_text(message, markup=markup)}"
+        log_body = _apply_tag_to_logmsg(tag, log_body)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["dryrun"],
-            message=f"[dry-run] {_message_to_log_text(message, markup=markup)}",
+            message=log_body,
             details=details,
         )
         style, detail_style, marker = self._resolve_with_overrides(
             "dryrun", style=style, detail_style=detail_style, marker=marker
         )
-        # Escape the leading [ so Rich doesn't parse "[dry-run]" as a markup tag.
+        # Escape the leading [ so Rich doesn't parse "[dry-run]" as a markup
+        # tag; the same escape applies when combining with a caller tag.
+        combined_tag = f"{tag} \\[dry-run]" if tag else "\\[dry-run]"
         _print_level(
             self.console,
             style=style,
@@ -754,11 +816,12 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
-            tag="\\[dry-run]",
+            tag=combined_tag,
+            right_tag=right_tag,
             **kwargs,
         )
 
-    def warning(
+    def warning(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -767,16 +830,18 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print warning output to stderr. Always shown, even when `quiet`.
 
         See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        semantics.
+        and `tag`/`right_tag` semantics.
         """
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["warning"],
-            message=_message_to_log_text(message, markup=markup),
+            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
             details=details,
         )
         style, detail_style, marker = self._resolve_with_overrides(
@@ -793,10 +858,12 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
+            tag=tag,
+            right_tag=right_tag,
             **kwargs,
         )
 
-    def error(
+    def error(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -805,16 +872,18 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print error output to stderr. Always shown, even when `quiet`.
 
         See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        semantics.
+        and `tag`/`right_tag` semantics.
         """
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["error"],
-            message=_message_to_log_text(message, markup=markup),
+            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
             details=details,
         )
         style, detail_style, marker = self._resolve_with_overrides(
@@ -829,10 +898,12 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
+            tag=tag,
+            right_tag=right_tag,
             **kwargs,
         )
 
-    def critical(
+    def critical(  # noqa: PLR0913
         self,
         message: str | RenderableType,
         *,
@@ -841,6 +912,8 @@ class Emitter:
         style: str | None = None,
         detail_style: str | None = None,
         marker: str | None = None,
+        tag: str | None = None,
+        right_tag: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Print critical output to stderr. Always shown, even when `quiet`.
@@ -852,11 +925,11 @@ class Emitter:
         `‼ `, customizable via `Theme(critical=Level(...))`).
 
         See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        semantics.
+        and `tag`/`right_tag` semantics.
         """
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["critical"],
-            message=_message_to_log_text(message, markup=markup),
+            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
             details=details,
         )
         style, detail_style, marker = self._resolve_with_overrides(
@@ -871,6 +944,8 @@ class Emitter:
             message=message,
             markup=markup,
             details=details,
+            tag=tag,
+            right_tag=right_tag,
             **kwargs,
         )
 
@@ -1077,7 +1152,7 @@ def configure(  # noqa: PLR0913
     )
 
 
-def info(
+def info(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1085,12 +1160,13 @@ def info(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print info-level output via the default emitter.
 
-    See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-    semantics.
+    See `Emitter.info` for full kwarg semantics including `tag`/`right_tag`.
     """
     _default.info(
         message,
@@ -1099,11 +1175,13 @@ def info(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 
 
-def success(
+def success(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1111,12 +1189,13 @@ def success(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print success-level output via the default emitter.
 
-    See `Emitter.success` for `message`/`markup`/`style`/`detail_style`/`marker`
-    semantics.
+    See `Emitter.success` for full kwarg semantics including `tag`/`right_tag`.
     """
     _default.success(
         message,
@@ -1125,11 +1204,13 @@ def success(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 
 
-def debug(
+def debug(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1137,12 +1218,13 @@ def debug(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print debug-level output via the default emitter.
 
-    See `Emitter.debug` for `message`/`markup`/`style`/`detail_style`/`marker`
-    semantics.
+    See `Emitter.debug` for full kwarg semantics including `tag`/`right_tag`.
     """
     _default.debug(
         message,
@@ -1151,11 +1233,13 @@ def debug(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 
 
-def trace(
+def trace(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1163,12 +1247,13 @@ def trace(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print trace-level output via the default emitter.
 
-    See `Emitter.trace` for `message`/`markup`/`style`/`detail_style`/`marker`
-    semantics.
+    See `Emitter.trace` for full kwarg semantics including `tag`/`right_tag`.
     """
     _default.trace(
         message,
@@ -1177,11 +1262,13 @@ def trace(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 
 
-def dryrun(
+def dryrun(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1189,12 +1276,13 @@ def dryrun(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print a dry-run notice via the default emitter.
 
-    See `Emitter.dryrun` for `message`/`markup`/`style`/`detail_style`/`marker`
-    semantics.
+    See `Emitter.dryrun` for full kwarg semantics including `tag`/`right_tag`.
     """
     _default.dryrun(
         message,
@@ -1203,11 +1291,13 @@ def dryrun(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 
 
-def warning(
+def warning(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1215,12 +1305,13 @@ def warning(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print warning output via the default emitter.
 
-    See `Emitter.warning` for `message`/`markup`/`style`/`detail_style`/`marker`
-    semantics.
+    See `Emitter.warning` for full kwarg semantics including `tag`/`right_tag`.
     """
     _default.warning(
         message,
@@ -1229,11 +1320,13 @@ def warning(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 
 
-def error(
+def error(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1241,12 +1334,13 @@ def error(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print error output via the default emitter.
 
-    See `Emitter.error` for `message`/`markup`/`style`/`detail_style`/`marker`
-    semantics.
+    See `Emitter.error` for full kwarg semantics including `tag`/`right_tag`.
     """
     _default.error(
         message,
@@ -1255,11 +1349,13 @@ def error(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 
 
-def critical(
+def critical(  # noqa: PLR0913
     message: str | RenderableType,
     *,
     details: list[Any] | None = None,
@@ -1267,11 +1363,14 @@ def critical(
     style: str | None = None,
     detail_style: str | None = None,
     marker: str | None = None,
+    tag: str | None = None,
+    right_tag: str | None = None,
     **kwargs: Any,
 ) -> None:
     """Print critical output via the default emitter. Always shown, even when `quiet`.
 
-    Severity-only; does not raise. See `Emitter.critical` for full semantics.
+    Severity-only; does not raise. See `Emitter.critical` for full semantics
+    including `tag`/`right_tag`.
     """
     _default.critical(
         message,
@@ -1280,6 +1379,8 @@ def critical(
         style=style,
         detail_style=detail_style,
         marker=marker,
+        tag=tag,
+        right_tag=right_tag,
         **kwargs,
     )
 

--- a/tests/pp/test_tags.py
+++ b/tests/pp/test_tags.py
@@ -1,0 +1,342 @@
+"""Tests for per-call `tag` and `right_tag` kwargs on level methods."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nclutils import pp
+from nclutils.pp.emitter import LogLevel, Verbosity, set_default
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .conftest import RecordingEmitterFactory
+
+
+class TestTagRendering:
+    """The `tag` kwarg renders dim between marker and message."""
+
+    @pytest.mark.parametrize("method", ["info", "success", "dryrun"])
+    def test_tag_appears_in_stdout_output(
+        self, make_recording_emitter: RecordingEmitterFactory, method: str
+    ) -> None:
+        """Verify tag kwarg renders between marker and message on stdout levels."""
+        # Given an emitter wired to a recording stdout console
+        e, out, _ = make_recording_emitter()
+
+        # When the level method is called with a tag
+        getattr(e, method)("hello", tag="api")
+
+        # Then the tag appears in the rendered text alongside the message
+        text = out.export_text()
+        assert "api" in text
+        assert "hello" in text
+
+    @pytest.mark.parametrize("method", ["warning", "error", "critical"])
+    def test_tag_appears_in_stderr_output(
+        self, make_recording_emitter: RecordingEmitterFactory, method: str
+    ) -> None:
+        """Verify tag kwarg renders alongside message on stderr levels."""
+        # Given an emitter wired to a recording stderr console
+        e, _, err = make_recording_emitter()
+
+        # When the level method is called with a tag
+        getattr(e, method)("hello", tag="api")
+
+        # Then the tag appears in stderr alongside the message
+        text = err.export_text()
+        assert "api" in text
+        assert "hello" in text
+
+    @pytest.mark.parametrize("method", ["debug", "trace"])
+    def test_tag_appears_for_debug_and_trace(
+        self, make_recording_emitter: RecordingEmitterFactory, method: str
+    ) -> None:
+        """Verify tag kwarg renders alongside debug/trace output when verbosity allows."""
+        # Given a TRACE-verbosity emitter so debug and trace render
+        e, out, _ = make_recording_emitter(verbosity=Verbosity.TRACE)
+
+        # When the verbose level method is called with a tag
+        getattr(e, method)("hello", tag="api")
+
+        # Then the tag appears in the recorded stdout
+        text = out.export_text()
+        assert "api" in text
+        assert "hello" in text
+
+
+class TestRightTagRendering:
+    """The `right_tag` kwarg renders dim, right-aligned on the first line."""
+
+    def test_right_tag_appears_in_output(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify right_tag kwarg renders alongside info-level output."""
+        # Given an emitter wired to a recording stdout console
+        e, out, _ = make_recording_emitter()
+
+        # When info is called with a right_tag
+        e.info("saved", right_tag="200ms")
+
+        # Then the right_tag appears in the rendered text
+        text = out.export_text()
+        assert "saved" in text
+        assert "200ms" in text
+
+
+class TestDryrunTagComposition:
+    """`dryrun` combines caller-supplied `tag` with the existing `[dry-run]` tag."""
+
+    def test_caller_tag_combines_with_dryrun_marker_on_console(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify caller tag renders before [dry-run] on the dryrun console output."""
+        # Given an emitter wired to a recording stdout console
+        e, out, _ = make_recording_emitter()
+
+        # When dryrun is called with a caller tag
+        e.dryrun("would deploy", tag="deploy")
+
+        # Then both tags render and the caller's tag precedes [dry-run]
+        text = out.export_text()
+        assert "deploy" in text
+        assert "[dry-run]" in text
+        assert text.index("deploy") < text.index("[dry-run]")
+
+    def test_caller_tag_combines_with_dryrun_marker_in_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify caller tag and [dry-run] both record inline in the dryrun logfile message."""
+        # Given an emitter with a logfile attached
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When dryrun is called with a caller tag
+        e.dryrun("would deploy", tag="deploy")
+
+        # Then the logfile contains both tags inline with the caller's tag first
+        contents = logfile.read_text()
+        assert "[deploy] [dry-run] would deploy" in contents
+
+    def test_dryrun_without_tag_keeps_existing_behavior(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify dryrun without a caller tag still records [dry-run] inline as before."""
+        # Given an emitter with a logfile attached
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When dryrun is called without a tag
+        e.dryrun("would deploy")
+
+        # Then the logfile contains the [dry-run] marker but no extra caller tag
+        contents = logfile.read_text()
+        assert "[dry-run] would deploy" in contents
+
+
+class TestDebugTraceRightTagConflict:
+    """Caller's right_tag replaces the auto-elapsed timestamp on console."""
+
+    def test_caller_right_tag_replaces_elapsed_on_console(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify caller-supplied right_tag replaces auto-elapsed [+s] tag on console."""
+        # Given a TRACE-verbosity emitter
+        e, out, _ = make_recording_emitter(verbosity=Verbosity.TRACE)
+
+        # When debug is called with an explicit right_tag
+        e.debug("query", right_tag="db: 1.2s")
+
+        # Then the caller's tag appears and the auto-elapsed marker is absent on console
+        text = out.export_text()
+        assert "db: 1.2s" in text
+        # the auto-elapsed marker uses [+s.fffs] format
+        assert "[+" not in text
+
+    def test_caller_right_tag_replaces_elapsed_on_trace_console(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify caller-supplied right_tag replaces auto-elapsed [+s] tag for trace too."""
+        # Given a TRACE-verbosity emitter
+        e, out, _ = make_recording_emitter(verbosity=Verbosity.TRACE)
+
+        # When trace is called with an explicit right_tag
+        e.trace("event", right_tag="rpc: 0.4s")
+
+        # Then the caller's tag appears and the auto-elapsed marker is absent on console
+        text = out.export_text()
+        assert "rpc: 0.4s" in text
+        assert "[+" not in text
+
+
+class TestTagInLogfile:
+    """`tag` is recorded inline in the logfile message; `right_tag` is presentation-only."""
+
+    def test_tag_appears_inline_in_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify tag appears as `[tag] msg` in the logfile."""
+        # Given an emitter with a logfile attached
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When info is called with a tag
+        e.info("saved", tag="api")
+
+        # Then the logfile contains `[api] saved`
+        contents = logfile.read_text()
+        assert "[api] saved" in contents
+
+    def test_right_tag_absent_from_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify right_tag does NOT appear in the logfile."""
+        # Given an emitter with a logfile attached
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When info is called with a right_tag
+        e.info("saved", right_tag="200ms")
+
+        # Then the logfile does NOT contain the right_tag value
+        contents = logfile.read_text()
+        assert "saved" in contents
+        assert "200ms" not in contents
+
+    def test_debug_logfile_keeps_elapsed_when_right_tag_set(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify debug logfile keeps auto-elapsed [+s] even when caller passes right_tag."""
+        # Given a TRACE-verbosity emitter with a TRACE-loglevel logfile so debug is captured
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(
+            verbosity=Verbosity.TRACE,
+            logfile=logfile,
+            loglevel=LogLevel.TRACE,
+        )
+
+        # When debug is called with an explicit right_tag
+        e.debug("query", right_tag="db: 1.2s")
+
+        # Then the logfile contains the [+s] elapsed marker (preserves audit trail)
+        contents = logfile.read_text()
+        assert "[+" in contents
+
+    def test_trace_logfile_keeps_elapsed_when_right_tag_set(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify trace logfile keeps auto-elapsed [+s] even when caller passes right_tag."""
+        # Given a TRACE-verbosity emitter with a TRACE-loglevel logfile so trace is captured
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(
+            verbosity=Verbosity.TRACE,
+            logfile=logfile,
+            loglevel=LogLevel.TRACE,
+        )
+
+        # When trace is called with an explicit right_tag
+        e.trace("event", right_tag="rpc: 0.4s")
+
+        # Then the logfile retains the elapsed marker
+        contents = logfile.read_text()
+        assert "[+" in contents
+
+    @pytest.mark.parametrize(
+        "method",
+        ["info", "success", "warning", "error", "critical"],
+    )
+    def test_tag_inline_for_non_dryrun_levels(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+        method: str,
+    ) -> None:
+        """Verify tag renders as `[tag] msg` in the logfile across non-dryrun levels."""
+        # Given an emitter with a logfile attached
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When the level method is called with a tag
+        getattr(e, method)("hello", tag="api")
+
+        # Then the logfile records the tag inline
+        contents = logfile.read_text()
+        assert "[api] hello" in contents
+
+
+class TestModuleLevelDelegation:
+    """Module-level functions forward tag/right_tag to the default emitter."""
+
+    @pytest.mark.usefixtures("isolated_default")
+    def test_module_level_info_forwards_tag(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify module-level pp.info() forwards tag through to the default emitter."""
+        # Given an isolated default emitter wired to a recording console
+        e, out, _ = make_recording_emitter()
+        set_default(e)
+
+        # When the module-level function is called with a tag
+        pp.info("hello", tag="api")
+
+        # Then the tag appears in the recorded output
+        text = out.export_text()
+        assert "api" in text
+        assert "hello" in text
+
+    @pytest.mark.usefixtures("isolated_default")
+    @pytest.mark.parametrize(
+        "method",
+        ["info", "success", "warning", "error", "critical", "dryrun"],
+    )
+    def test_module_level_levels_forward_right_tag(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        method: str,
+    ) -> None:
+        """Verify module-level level functions forward right_tag through to the default emitter."""
+        # Given an isolated default emitter wired to a recording console
+        e, out, err = make_recording_emitter()
+        set_default(e)
+
+        # When the module-level function is called with a right_tag
+        getattr(pp, method)("hello", right_tag="200ms")
+
+        # Then the right_tag appears in the recorded output (stdout or stderr)
+        combined = out.export_text() + err.export_text()
+        assert "200ms" in combined
+        assert "hello" in combined
+
+    @pytest.mark.usefixtures("isolated_default")
+    @pytest.mark.parametrize("method", ["debug", "trace"])
+    def test_module_level_debug_trace_forward_right_tag(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        method: str,
+    ) -> None:
+        """Verify module-level debug/trace forward right_tag and replace the elapsed marker."""
+        # Given an isolated TRACE-verbosity default emitter
+        e, out, _ = make_recording_emitter(verbosity=Verbosity.TRACE)
+        set_default(e)
+
+        # When the module-level function is called with a right_tag
+        getattr(pp, method)("hello", right_tag="custom")
+
+        # Then the caller's right_tag replaces the auto-elapsed marker on the console
+        text = out.export_text()
+        assert "custom" in text
+        assert "[+" not in text


### PR DESCRIPTION
## Summary
- Adds `tag=` (dim left-side metadata) and `right_tag=` (dim right-aligned, presentation-only) to every level method on `Emitter` and the module-level functions: `info`, `success`, `warning`, `error`, `critical`, `debug`, `trace`, `dryrun`.
- `tag` is recorded inline in the logfile message (`[tag] msg`) so audit grep finds the same labels the operator saw on the console; `right_tag` is presentation-only and never written to the logfile.
- Caller-supplied `right_tag` on `debug`/`trace` replaces the auto-elapsed `[+s.fffs]` marker on the console while the logfile still records the elapsed timing.
- `dryrun` combines a caller-supplied `tag` with its existing `[dry-run]` marker on both the console and in the logfile, with the caller's tag rendered first.

## Test plan
- [x] `duty test` passes (374 tests)
- [x] `duty lint` passes
- [x] `uv run scripts/pp_demo.py` shows the new "Per-call tags" section rendering correctly