### PR TITLE
feat(pp): add success_msg and failure_msg to step()

### DIFF
--- a/docs/pp.md
+++ b/docs/pp.md
@@ -199,6 +199,27 @@ with pp.step("warming caches", ephemeral=True) as s:
 > [!WARNING]
 > `pp.step()` cannot nest. Rich's `Live` doesn't stack, so nesting silently corrupts the parent's display. `pp` raises `RuntimeError` when you try.
 
+### Customizing the success and failure messages
+
+By default `step()` reuses the original message for both success and failure. To show different text on completion, pass `success_msg` and/or `failure_msg`:
+
+```python
+with pp.step(
+    "compiling sources",
+    success_msg="compiled 42 files in 1.2s",
+    failure_msg="compilation aborted",
+) as s:
+    s.sub("api.py")
+    s.sub("cli.py")
+```
+
+On success the spinner resolves to `✓ compiled 42 files in 1.2s`; on failure to `✗ compilation aborted`. Either kwarg can be omitted independently, and the omitted side falls back to the original message. The single `markup=` flag covers all three messages.
+
+The override messages are also recorded in the logfile (`succeeded: ...` / `failed: ...`) so the audit trail matches what the user saw.
+
+> [!NOTE]
+> When `ephemeral=True`, the success branch wipes the screen as usual; `success_msg` is still recorded in the logfile. The failure branch surfaces `failure_msg` on stderr if provided, otherwise the original message.
+
 ## File logging
 
 Pass `logfile=` to write a parallel record of every emission to disk:

--- a/scripts/pp_demo.py
+++ b/scripts/pp_demo.py
@@ -57,6 +57,24 @@ def _steps() -> None:
     with pp.step("ephemeral path", ephemeral=True) as s:
         s.sub("disappears on success")
 
+    with pp.step(
+        "compiling sources",
+        success_msg="compiled 42 files in 1.2s",
+    ) as s:
+        s.sub("api.py")
+        s.sub("cli.py")
+
+    try:
+        with pp.step(
+            "uploading artifact",
+            failure_msg="upload aborted (network error)",
+        ) as s:
+            s.sub("packing tarball")
+            msg = "boom"
+            raise RuntimeError(msg)  # noqa: TRY301 -- intentional, exercises failure_msg path
+    except RuntimeError:
+        pass
+
 
 def _details_simple() -> None:
     """Demonstrate details with tree connectors: single, multiple, and markup."""

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -1003,6 +1003,8 @@ class Emitter:
         *,
         ephemeral: bool = False,
         markup: bool = False,
+        success_msg: str | RenderableType | None = None,
+        failure_msg: str | RenderableType | None = None,
     ) -> Generator[Step]:
         """Show a spinner while the block runs, then a completion marker.
 
@@ -1016,6 +1018,14 @@ class Emitter:
         console on completion. Success leaves no trace; failure prints only the
         error marker so errors are not silently hidden.
 
+        `success_msg` overrides the success-state header; defaults to the
+        original `message` styled as success. `failure_msg` overrides the
+        failure-state header; defaults to the original `message` styled as
+        error. Either side may be omitted independently. The single `markup=`
+        flag covers all three messages. The succeeded:/failed: log lines also
+        use the override messages when provided so the audit trail matches
+        what the user saw on the console.
+
         Args:
             message: Title shown next to the spinner. Strings are escaped by
                 default; pass `markup=True` to embed Rich markup. A `Text`
@@ -1024,6 +1034,10 @@ class Emitter:
             ephemeral: If True, clear sub-items and the success marker on completion.
             markup: When True, parses Rich markup in a `str` `message`
                 instead of escaping.
+            success_msg: Optional message to display on success in place of
+                the original `message`. Falls back to `message` when None.
+            failure_msg: Optional message to display on failure in place of
+                the original `message`. Falls back to `message` when None.
 
         Yields:
             A `Step` whose `sub()` method appends sub-items beneath the spinner.
@@ -1040,7 +1054,20 @@ class Emitter:
         info_style, _, _ = self._resolve("info")
         success_style, _, success_marker = self._resolve("success")
         error_style, _, error_marker = self._resolve("error")
+
         log_text = _message_to_log_text(message, markup=markup)
+        success_text = (
+            _message_to_log_text(success_msg, markup=markup)
+            if success_msg is not None
+            else log_text
+        )
+        failure_text = (
+            _message_to_log_text(failure_msg, markup=markup)
+            if failure_msg is not None
+            else log_text
+        )
+        success_message = success_msg if success_msg is not None else message
+        failure_message = failure_msg if failure_msg is not None else message
 
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["info"],
@@ -1058,14 +1085,20 @@ class Emitter:
                     failed_exc = exc
                     if not ephemeral:
                         error_header = _build_message_text(
-                            message, style=error_style, marker=error_marker, markup=markup
+                            failure_message,
+                            style=error_style,
+                            marker=error_marker,
+                            markup=markup,
                         )
                         if error_header is not None:
                             s.header = error_header
                     raise
                 if not ephemeral:
                     success_header = _build_message_text(
-                        message, style=success_style, marker=success_marker, markup=markup
+                        success_message,
+                        style=success_style,
+                        marker=success_marker,
+                        markup=markup,
                     )
                     if success_header is not None:
                         s.header = success_header
@@ -1074,15 +1107,15 @@ class Emitter:
             if failed_exc is not None:
                 self._logsink.emit(
                     level=_LEVEL_TO_LOG_SEVERITY["error"],
-                    message=f"failed: {log_text}",
+                    message=f"failed: {failure_text}",
                     details=[f"{type(failed_exc).__name__}: {failed_exc}"],
                 )
                 if ephemeral:
-                    self.error(log_text)
+                    self.error(failure_text)
             else:
                 self._logsink.emit(
                     level=_LEVEL_TO_LOG_SEVERITY["info"],
-                    message=f"succeeded: {log_text}",
+                    message=f"succeeded: {success_text}",
                     details=None,
                 )
 
@@ -1401,13 +1434,24 @@ def header(
 
 @contextmanager
 def step(
-    message: str | RenderableType, *, ephemeral: bool = False, markup: bool = False
+    message: str | RenderableType,
+    *,
+    ephemeral: bool = False,
+    markup: bool = False,
+    success_msg: str | RenderableType | None = None,
+    failure_msg: str | RenderableType | None = None,
 ) -> Generator[Step]:
     """Run a spinner-driven step on the default emitter.
 
-    See `Emitter.step` for `message`/`markup` semantics.
+    See `Emitter.step` for `message`/`markup`/`success_msg`/`failure_msg` semantics.
     """
-    with _default.step(message, ephemeral=ephemeral, markup=markup) as s:
+    with _default.step(
+        message,
+        ephemeral=ephemeral,
+        markup=markup,
+        success_msg=success_msg,
+        failure_msg=failure_msg,
+    ) as s:
         yield s
 
 

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -1090,8 +1090,9 @@ class Emitter:
                             marker=error_marker,
                             markup=markup,
                         )
-                        if error_header is not None:
-                            s.header = error_header
+                        # _build_message_text returns None for non-(str|Text) renderables;
+                        # fall back to the original renderable so the override is not silently dropped.
+                        s.header = error_header if error_header is not None else failure_message
                     raise
                 if not ephemeral:
                     success_header = _build_message_text(
@@ -1100,8 +1101,9 @@ class Emitter:
                         marker=success_marker,
                         markup=markup,
                     )
-                    if success_header is not None:
-                        s.header = success_header
+                    # _build_message_text returns None for non-(str|Text) renderables;
+                    # fall back to the original renderable so the override is not silently dropped.
+                    s.header = success_header if success_header is not None else success_message
         finally:
             self._active_step = False
             if failed_exc is not None:
@@ -1111,7 +1113,8 @@ class Emitter:
                     details=[f"{type(failed_exc).__name__}: {failed_exc}"],
                 )
                 if ephemeral:
-                    self.error(failure_text)
+                    # Pass the original renderable (not the plain-text strip) so styling/markup is preserved.
+                    self.error(failure_message)
             else:
                 self._logsink.emit(
                     level=_LEVEL_TO_LOG_SEVERITY["info"],

--- a/tests/pp/test_step_msgs.py
+++ b/tests/pp/test_step_msgs.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from rich.padding import Padding
+from rich.text import Text
 
 from nclutils.pp import emitter as pp_emitter
 
@@ -46,6 +48,21 @@ class TestStepSuccessMsg:
         # Then the original message appears in the success line
         text = out.export_text()
         assert "compiling" in text
+
+    def test_success_msg_renderable_replaces_header(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify success_msg accepts an arbitrary Rich renderable and the override is applied."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+
+        # When step() runs to success with a renderable success_msg
+        with e.step("compiling", success_msg=Padding("compiled 42 files", (0, 1))):
+            pass
+
+        # Then the override text appears in the rendered output
+        text = out.export_text()
+        assert "compiled 42 files" in text
 
 
 class TestStepFailureMsg:
@@ -214,6 +231,29 @@ class TestEphemeralStepInteraction:
         text = err.export_text()
         assert "warming caches" in text
 
+    def test_ephemeral_failure_preserves_failure_msg_styling(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+    ) -> None:
+        """Verify ephemeral failure preserves Rich markup styling in failure_msg."""
+        # Given an emitter wired to recording stderr
+        e, _, err = make_recording_emitter()
+        err_msg = "boom"
+
+        # When step() raises ephemerally with a styled failure_msg
+        styled = Text("cache priming failed", style="bold red")
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            e.step("warming", ephemeral=True, failure_msg=styled),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then the styled fragment appears in the recorded HTML output with styling preserved
+        html = err.export_html()
+        assert "cache priming failed" in html
+        # The styling marker should be present (red color or bold weight)
+        assert "color: " in html or "font-weight" in html
+
 
 class TestModuleLevelStep:
     """Module-level `step()` forwards override kwargs to the default emitter."""
@@ -257,3 +297,43 @@ class TestModuleLevelStep:
         # Then the override message appears in the rendered output
         text = out.export_text()
         assert "compilation aborted" in text
+
+
+class TestMarkupAppliesToOverrides:
+    """`markup=True` parses Rich markup in success_msg and failure_msg."""
+
+    def test_markup_true_parses_success_msg(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify markup=True parses Rich markup tags in success_msg."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+
+        # When step() runs to success with a markup-containing override and markup=True
+        with e.step("compiling", success_msg="[bold]compiled all[/]", markup=True):
+            pass
+
+        # Then the rendered output contains the message text but not the literal markup tags
+        text = out.export_text()
+        assert "compiled all" in text
+        assert "[bold]" not in text
+
+    def test_markup_true_parses_failure_msg(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify markup=True parses Rich markup tags in failure_msg."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+        err_msg = "boom"
+
+        # When step() raises with a markup-containing override and markup=True
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            e.step("compiling", failure_msg="[bold]aborted[/]", markup=True),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then the rendered output contains the message text but not the literal markup tags
+        text = out.export_text()
+        assert "aborted" in text
+        assert "[bold]" not in text

--- a/tests/pp/test_step_msgs.py
+++ b/tests/pp/test_step_msgs.py
@@ -1,0 +1,259 @@
+"""Tests for step() success_msg and failure_msg kwargs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nclutils.pp import emitter as pp_emitter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .conftest import RecordingEmitterFactory
+
+
+class TestStepSuccessMsg:
+    """`success_msg` swaps the success header text on completion."""
+
+    def test_success_msg_replaces_header_on_success(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify success_msg appears in place of the original message on success."""
+        # Given an emitter wired to a recording console
+        e, out, _ = make_recording_emitter()
+
+        # When step() runs to success with a success_msg override
+        with e.step("compiling", success_msg="compiled 42 files"):
+            pass
+
+        # Then the override message appears in the rendered output
+        text = out.export_text()
+        assert "compiled 42 files" in text
+
+    def test_success_msg_default_keeps_original(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify omitting success_msg preserves current behavior (original message kept)."""
+        # Given an emitter wired to a recording console
+        e, out, _ = make_recording_emitter()
+
+        # When step() runs without override kwargs
+        with e.step("compiling"):
+            pass
+
+        # Then the original message appears in the success line
+        text = out.export_text()
+        assert "compiling" in text
+
+
+class TestStepFailureMsg:
+    """`failure_msg` swaps the error header text on exception."""
+
+    def test_failure_msg_replaces_header_on_exception(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify failure_msg appears in place of the original message on exception."""
+        # Given an emitter wired to a recording console
+        e, out, _ = make_recording_emitter()
+        err_msg = "boom"
+
+        # When step() raises with a failure_msg override
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            e.step("compiling", failure_msg="compilation aborted"),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then the failure_msg appears in the rendered output
+        text = out.export_text()
+        assert "compilation aborted" in text
+
+    def test_failure_msg_default_keeps_original(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify omitting failure_msg preserves current behavior (original message kept)."""
+        # Given an emitter wired to a recording console
+        e, out, _ = make_recording_emitter()
+        err_msg = "boom"
+
+        # When step() raises without override kwargs
+        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling"):
+            raise RuntimeError(err_msg)
+
+        # Then the original message appears in the failure line
+        text = out.export_text()
+        assert "compiling" in text
+
+
+class TestStepLogfile:
+    """Override messages are recorded in the logfile lifecycle records."""
+
+    def test_success_msg_in_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify the succeeded: line in the logfile uses success_msg when provided."""
+        # Given an emitter with a logfile
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When step() succeeds with an override
+        with e.step("compiling", success_msg="compiled 42 files"):
+            pass
+
+        # Then the logfile records the override message in the succeeded: line
+        contents = logfile.read_text()
+        assert "succeeded: compiled 42 files" in contents
+
+    def test_failure_msg_in_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify the failed: line in the logfile uses failure_msg when provided."""
+        # Given an emitter with a logfile
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+        err_msg = "boom"
+
+        # When step() raises with an override
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            e.step("compiling", failure_msg="compilation aborted"),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then the logfile records the override message in the failed: line
+        contents = logfile.read_text()
+        assert "failed: compilation aborted" in contents
+
+    def test_success_default_logs_original_message(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify omitting success_msg keeps original message in the logfile succeeded: line."""
+        # Given an emitter with a logfile and no override
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When step() succeeds without overrides
+        with e.step("compiling"):
+            pass
+
+        # Then the logfile records the original message
+        contents = logfile.read_text()
+        assert "succeeded: compiling" in contents
+
+
+class TestEphemeralStepInteraction:
+    """`ephemeral=True` interacts correctly with override messages."""
+
+    def test_ephemeral_success_records_msg_in_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify ephemeral success records success_msg in the logfile even though console is wiped."""
+        # Given an emitter with logfile and ephemeral step
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When step() runs ephemerally with a success_msg
+        with e.step("warming caches", ephemeral=True, success_msg="caches warm"):
+            pass
+
+        # Then logfile records the override message
+        contents = logfile.read_text()
+        assert "succeeded: caches warm" in contents
+
+    def test_ephemeral_failure_displays_failure_msg(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+    ) -> None:
+        """Verify ephemeral failure surfaces failure_msg on stderr."""
+        # Given an emitter wired to recording stderr
+        e, _, err = make_recording_emitter()
+        err_msg = "boom"
+
+        # When step() raises in ephemeral mode with a failure_msg
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            e.step(
+                "warming caches",
+                ephemeral=True,
+                failure_msg="cache priming failed",
+            ),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then the failure_msg appears in the surfaced error output
+        text = err.export_text()
+        assert "cache priming failed" in text
+
+    def test_ephemeral_failure_default_surfaces_original(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+    ) -> None:
+        """Verify ephemeral failure falls back to the original message on stderr without override."""
+        # Given an emitter wired to recording stderr
+        e, _, err = make_recording_emitter()
+        err_msg = "boom"
+
+        # When step() raises in ephemeral mode without a failure_msg
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            e.step("warming caches", ephemeral=True),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then the original message appears in the surfaced error output
+        text = err.export_text()
+        assert "warming caches" in text
+
+
+class TestModuleLevelStep:
+    """Module-level `step()` forwards override kwargs to the default emitter."""
+
+    def test_module_step_accepts_success_msg(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        isolated_default: None,
+    ) -> None:
+        """Verify the module-level step() forwards success_msg to the default emitter."""
+        # Given the default emitter is replaced with a recording one
+        e, out, _ = make_recording_emitter()
+        pp_emitter.set_default(e)
+
+        # When the module-level step() runs with a success_msg override
+        with pp_emitter.step("compiling", success_msg="compiled 42 files"):
+            pass
+
+        # Then the override message appears in the rendered output
+        text = out.export_text()
+        assert "compiled 42 files" in text
+
+    def test_module_step_accepts_failure_msg(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        isolated_default: None,
+    ) -> None:
+        """Verify the module-level step() forwards failure_msg to the default emitter."""
+        # Given the default emitter is replaced with a recording one
+        e, out, _ = make_recording_emitter()
+        pp_emitter.set_default(e)
+        err_msg = "boom"
+
+        # When the module-level step() raises with a failure_msg override
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            pp_emitter.step("compiling", failure_msg="compilation aborted"),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then the override message appears in the rendered output
+        text = out.export_text()
+        assert "compilation aborted" in text


### PR DESCRIPTION
## Summary
- `pp.step()` and `Emitter.step()` accept new `success_msg=` and `failure_msg=` kwargs to override the spinner header on completion.
- Either side can be omitted independently; omitted sides fall back to the original `message`.
- Override messages are recorded in the logfile lifecycle records (`succeeded:` / `failed:`) so the audit trail matches what the user saw.
- `ephemeral=True` interaction documented and tested: success keeps the screen clean while still logging the override; failure surfaces the override on stderr.

## Test plan
- [x] `duty test` passes (386 tests)
- [x] `duty lint` passes
- [x] `uv run scripts/pp_demo.py` shows the new step variants rendering as expected