### PR TITLE
feat(pp): add exception kwarg to level methods

### DIFF
--- a/docs/pp.md
+++ b/docs/pp.md
@@ -121,6 +121,44 @@ When `right_tag` is passed to `pp.debug` or `pp.trace`, the caller's value repla
 > [!NOTE]
 > The caller is responsible for Rich-markup-escaping any `[`, `]`, or other reserved characters in `tag` and `right_tag`. Pass plain ASCII tags or pre-escaped strings.
 
+### Exceptions and tracebacks
+
+Every level method accepts an `exception=` kwarg. Pass an exception instance to render a styled Rich Traceback below the message:
+
+```python
+try:
+    upload()
+except UploadError as exc:
+    pp.error("upload failed", exception=exc)
+```
+
+```text
+✗ upload failed
+  └─ ╭─ Traceback ─────────────────────────────────
+       File "upload.py", line 42, in upload
+         raise UploadError("403 Forbidden")
+       UploadError: 403 Forbidden
+     ╰─────────────────────────────────────────────
+```
+
+Inside an `except` block you can pass `exception=True` to grab the active exception via `sys.exc_info()`:
+
+```python
+try:
+    upload()
+except UploadError:
+    pp.error("upload failed", exception=True)
+```
+
+Outside an `except` block, `exception=True` is a silent no-op (matches the behavior of `logging.exception()`).
+
+Pass `show_locals=True` for verbose dumps that include each frame's local variables. Rich handles its own glyph fallbacks based on console encoding, so the traceback renders cleanly on terminals that can't display box-drawing characters.
+
+The formatted traceback is also written to the logfile as continuation lines under the parent record at the same severity, so a level filter drops the traceback alongside its message.
+
+> [!NOTE]
+> `exception=` is accepted on every level method (`info`, `success`, `warning`, `error`, `critical`, `debug`, `trace`, `dryrun`). It is not supported on `header()` or `step()`, both of which already manage their own exception display.
+
 You can pass Rich renderables in `details` to get syntax-aware output, which is especially useful at `debug` / `trace`:
 
 ```python
@@ -370,7 +408,7 @@ finally:
 
 Every name below is available on the `pp` namespace (`from nclutils import pp`) and from `nclutils.pp` directly (e.g. `from nclutils.pp import info`).
 
-- `info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`, `header`. Output functions. Every level function accepts `tag=` and `right_tag=` kwargs - see [Per-call tags](#per-call-tags) above.
+- `info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`, `header`. Output functions. Every level function accepts `tag=` / `right_tag=` (see [Per-call tags](#per-call-tags)) and `exception=` / `show_locals=` (see [Exceptions and tracebacks](#exceptions-and-tracebacks)).
 - `step(message, *, ephemeral=False)`. Spinner context manager.
 - `configure(*, verbosity=None, quiet=None, console=None, err_console=None, theme=None, logfile=None, loglevel=None, logfmt=None)`. Partial update of the default emitter.
 - `Emitter`. Instantiate directly for isolated configuration.

--- a/scripts/pp_demo.py
+++ b/scripts/pp_demo.py
@@ -127,6 +127,29 @@ def _per_call_tags() -> None:
     pp.debug("auto elapsed (default)")
 
 
+def _exceptions() -> None:
+    """Demonstrate the exception= kwarg with instance, True, and show_locals forms."""
+    pp.header("Exceptions", align="left")
+
+    try:
+        msg = "403 Forbidden"
+        raise RuntimeError(msg)  # noqa: TRY301 -- intentional, exercises exception= instance form
+    except RuntimeError as exc:
+        pp.error("upload failed (instance)", exception=exc)
+
+    try:
+        msg = "boom"
+        raise ValueError(msg)  # noqa: TRY301 -- intentional, exercises exception=True form
+    except ValueError:
+        pp.error("operation aborted (exception=True)", exception=True)
+
+    try:
+        msg = "verbose"
+        raise KeyError(msg)  # noqa: TRY301 -- intentional, exercises show_locals=True form
+    except KeyError as exc:
+        pp.warning("retry triggered (show_locals=True)", exception=exc, show_locals=True)
+
+
 def _theme_override() -> None:
     """Demonstrate a custom Theme via a dedicated Emitter."""
     pp.header("Theme override", align="left")
@@ -178,6 +201,7 @@ def main() -> None:
     _details_multiline()
     _per_call_overrides()
     _per_call_tags()
+    _exceptions()
     _theme_override()
     _verbosity_matrix()
 

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -10,7 +10,9 @@ terminal, no instance threading.
 from __future__ import annotations
 
 import logging
+import sys
 import time
+import traceback as _traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -223,6 +225,69 @@ def _apply_tag_to_logmsg(tag: str | None, message: str) -> str:
     if tag:
         return f"[{tag}] {message}"
     return message
+
+
+def _resolve_exception(exception: BaseException | bool) -> BaseException | None:  # noqa: FBT001 -- bool is a real value in the public contract (mirrors logging.exception)
+    """Resolve the `exception=` kwarg to an actual exception instance or None.
+
+    `False` returns None. `True` calls `sys.exc_info()` and returns the active
+    exception (None if there isn't one, matching `logging.exception()` semantics
+    so callers outside an `except` block become a silent no-op). A
+    `BaseException` instance is returned as-is.
+    """
+    if exception is False:
+        return None
+    if exception is True:
+        _, exc, _ = sys.exc_info()
+        return exc
+    return exception
+
+
+def _attach_exception_to_details(
+    details: list[Any] | None,
+    exception: BaseException | bool,  # noqa: FBT001 -- bool is a real value in the public contract
+    *,
+    show_locals: bool,
+) -> list[Any] | None:
+    """Append a Rich Traceback for `exception` to `details`.
+
+    Returns a new list with the Traceback renderable as the final item, or
+    `details` unchanged when `exception` resolves to no traceback. Imports
+    `rich.traceback.Traceback` lazily so callers that never use this kwarg
+    don't pay the import cost at module load time.
+    """
+    exc = _resolve_exception(exception)
+    if exc is None:
+        return details
+    # Lazy import: callers without exception= avoid the rich.traceback module cost.
+    from rich.traceback import Traceback  # noqa: PLC0415
+
+    rich_tb = Traceback.from_exception(
+        type(exc),
+        exc,
+        exc.__traceback__,
+        show_locals=show_locals,
+    )
+    new_details = list(details) if details else []
+    new_details.append(rich_tb)
+    return new_details
+
+
+def _format_exception_for_logfile(exception: BaseException | bool) -> list[str] | None:  # noqa: FBT001 -- bool is a real value in the public contract
+    """Format an exception's traceback as a list of strings for logfile continuation lines.
+
+    Returns None when there's nothing to attach (`exception=False` or
+    `exception=True` with no active exception). The resulting strings have no
+    color codes; the logfile path strips Rich coloring anyway.
+    """
+    exc = _resolve_exception(exception)
+    if exc is None:
+        return None
+    return [
+        line.rstrip("\n")
+        for chunk in _traceback.format_exception(type(exc), exc, exc.__traceback__)
+        for line in chunk.splitlines()
+    ]
 
 
 def _print_level(  # noqa: PLR0913
@@ -564,6 +629,8 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print info-level output to stdout. Suppressed when `quiet` is True.
@@ -593,11 +660,24 @@ class Emitter:
         only. It is presentation-only and is NOT recorded in the logfile. The
         caller is responsible for escaping any Rich markup characters in the
         tag.
+
+        `exception` attaches a styled Rich Traceback below the message. Pass
+        an explicit exception instance, or `True` inside an `except` block to
+        grab `sys.exc_info()`. Outside an except block, `exception=True` is a
+        silent no-op (matches `logging.exception()` behavior). The formatted
+        traceback is also written to the logfile as continuation lines under
+        the parent record at the same severity. `show_locals=True` flows
+        through to Rich's Traceback for verbose dumps.
         """
+        log_message = _apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup))
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["info"],
-            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
-            details=details,
+            message=log_message,
+            details=log_details or None,
         )
         if self.quiet:
             return
@@ -611,7 +691,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=tag,
             right_tag=right_tag,
             **kwargs,
@@ -628,6 +708,8 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print success-level output to stdout. Suppressed when `quiet` is True.
@@ -637,13 +719,18 @@ class Emitter:
         (`JSON`, `Syntax`, `Table`, …) pass through unchanged; anything else
         is wrapped in `Pretty()`.
 
-        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        and `tag`/`right_tag` semantics.
+        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`,
+        `tag`/`right_tag`, and `exception`/`show_locals` semantics.
         """
+        log_message = _apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup))
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["success"],
-            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
-            details=details,
+            message=log_message,
+            details=log_details or None,
         )
         if self.quiet:
             return
@@ -657,7 +744,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=tag,
             right_tag=right_tag,
             **kwargs,
@@ -674,6 +761,8 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print debug-level output to stdout. Shown with `-v` or higher.
@@ -687,17 +776,22 @@ class Emitter:
         for one call (e.g. `right_tag="db: 1.2s"`); the logfile still records
         the auto-elapsed `[+s.fffs]` marker so the audit timeline is preserved.
 
-        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        and `tag`/`right_tag` semantics.
+        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`,
+        `tag`/`right_tag`, and `exception`/`show_locals` semantics.
         """
         elapsed = self._elapsed_tag()
+        log_message = _apply_tag_to_logmsg(
+            tag,
+            f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
+        )
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["debug"],
-            message=_apply_tag_to_logmsg(
-                tag,
-                f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
-            ),
-            details=details,
+            message=log_message,
+            details=log_details or None,
         )
         if self.verbosity < Verbosity.DEBUG:
             return
@@ -711,7 +805,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=tag,
             right_tag=right_tag if right_tag is not None else elapsed,
             **kwargs,
@@ -728,6 +822,8 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print trace-level output to stdout. Shown with `-vv`.
@@ -736,18 +832,23 @@ class Emitter:
         for one call; the logfile still records the auto-elapsed `[+s.fffs]`
         marker so the audit timeline is preserved.
 
-        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        and `tag`/`right_tag` semantics, and `Emitter.debug` for the
-        right-aligned elapsed tag.
+        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`,
+        `tag`/`right_tag`, and `exception`/`show_locals` semantics, and
+        `Emitter.debug` for the right-aligned elapsed tag.
         """
         elapsed = self._elapsed_tag()
+        log_message = _apply_tag_to_logmsg(
+            tag,
+            f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
+        )
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["trace"],
-            message=_apply_tag_to_logmsg(
-                tag,
-                f"{_message_to_log_text(message, markup=markup)}  {elapsed}",
-            ),
-            details=details,
+            message=log_message,
+            details=log_details or None,
         )
         if self.verbosity < Verbosity.TRACE:
             return
@@ -761,7 +862,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=tag,
             right_tag=right_tag if right_tag is not None else elapsed,
             **kwargs,
@@ -778,6 +879,8 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print a dry-run notice to stdout. Always shown, even when `quiet`.
@@ -789,18 +892,22 @@ class Emitter:
         marker (e.g. `[deploy] [dry-run] would push`) on both the console
         and in the logfile.
 
-        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        and `tag`/`right_tag` semantics.
+        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`,
+        `tag`/`right_tag`, and `exception`/`show_locals` semantics.
         """
         # Include [dry-run] inline in the file message for grep-ability, and
         # prepend any caller-supplied tag so audit grep finds the same labels
         # the operator saw on the console.
         log_body = f"[dry-run] {_message_to_log_text(message, markup=markup)}"
         log_body = _apply_tag_to_logmsg(tag, log_body)
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["dryrun"],
             message=log_body,
-            details=details,
+            details=log_details or None,
         )
         style, detail_style, marker = self._resolve_with_overrides(
             "dryrun", style=style, detail_style=detail_style, marker=marker
@@ -815,7 +922,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=combined_tag,
             right_tag=right_tag,
             **kwargs,
@@ -832,17 +939,24 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print warning output to stderr. Always shown, even when `quiet`.
 
-        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        and `tag`/`right_tag` semantics.
+        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`,
+        `tag`/`right_tag`, and `exception`/`show_locals` semantics.
         """
+        log_message = _apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup))
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["warning"],
-            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
-            details=details,
+            message=log_message,
+            details=log_details or None,
         )
         style, detail_style, marker = self._resolve_with_overrides(
             "warning", style=style, detail_style=detail_style, marker=marker
@@ -857,7 +971,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=tag,
             right_tag=right_tag,
             **kwargs,
@@ -874,17 +988,27 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print error output to stderr. Always shown, even when `quiet`.
 
-        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        and `tag`/`right_tag` semantics.
+        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`,
+        `tag`/`right_tag`, and `exception`/`show_locals` semantics. The
+        `exception=` kwarg is particularly natural here: pass `True` from
+        inside an `except` block to attach the active traceback alongside the
+        message.
         """
+        log_message = _apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup))
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["error"],
-            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
-            details=details,
+            message=log_message,
+            details=log_details or None,
         )
         style, detail_style, marker = self._resolve_with_overrides(
             "error", style=style, detail_style=detail_style, marker=marker
@@ -897,7 +1021,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=tag,
             right_tag=right_tag,
             **kwargs,
@@ -914,6 +1038,8 @@ class Emitter:
         marker: str | None = None,
         tag: str | None = None,
         right_tag: str | None = None,
+        exception: BaseException | bool = False,
+        show_locals: bool = False,
         **kwargs: Any,
     ) -> None:
         """Print critical output to stderr. Always shown, even when `quiet`.
@@ -924,13 +1050,18 @@ class Emitter:
         with the level's resolved style, detail style, and marker (default
         `‼ `, customizable via `Theme(critical=Level(...))`).
 
-        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`
-        and `tag`/`right_tag` semantics.
+        See `Emitter.info` for `message`/`markup`/`style`/`detail_style`/`marker`,
+        `tag`/`right_tag`, and `exception`/`show_locals` semantics.
         """
+        log_message = _apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup))
+        log_details = list(details) if details else []
+        tb_lines = _format_exception_for_logfile(exception)
+        if tb_lines:
+            log_details.extend(tb_lines)
         self._logsink.emit(
             level=_LEVEL_TO_LOG_SEVERITY["critical"],
-            message=_apply_tag_to_logmsg(tag, _message_to_log_text(message, markup=markup)),
-            details=details,
+            message=log_message,
+            details=log_details or None,
         )
         style, detail_style, marker = self._resolve_with_overrides(
             "critical", style=style, detail_style=detail_style, marker=marker
@@ -943,7 +1074,7 @@ class Emitter:
             marker=marker,
             message=message,
             markup=markup,
-            details=details,
+            details=_attach_exception_to_details(details, exception, show_locals=show_locals),
             tag=tag,
             right_tag=right_tag,
             **kwargs,
@@ -1198,11 +1329,14 @@ def info(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print info-level output via the default emitter.
 
-    See `Emitter.info` for full kwarg semantics including `tag`/`right_tag`.
+    See `Emitter.info` for full kwarg semantics including `tag`/`right_tag`
+    and `exception`/`show_locals`.
     """
     _default.info(
         message,
@@ -1213,6 +1347,8 @@ def info(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 
@@ -1227,11 +1363,14 @@ def success(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print success-level output via the default emitter.
 
-    See `Emitter.success` for full kwarg semantics including `tag`/`right_tag`.
+    See `Emitter.success` for full kwarg semantics including `tag`/`right_tag`
+    and `exception`/`show_locals`.
     """
     _default.success(
         message,
@@ -1242,6 +1381,8 @@ def success(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 
@@ -1256,11 +1397,14 @@ def debug(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print debug-level output via the default emitter.
 
-    See `Emitter.debug` for full kwarg semantics including `tag`/`right_tag`.
+    See `Emitter.debug` for full kwarg semantics including `tag`/`right_tag`
+    and `exception`/`show_locals`.
     """
     _default.debug(
         message,
@@ -1271,6 +1415,8 @@ def debug(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 
@@ -1285,11 +1431,14 @@ def trace(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print trace-level output via the default emitter.
 
-    See `Emitter.trace` for full kwarg semantics including `tag`/`right_tag`.
+    See `Emitter.trace` for full kwarg semantics including `tag`/`right_tag`
+    and `exception`/`show_locals`.
     """
     _default.trace(
         message,
@@ -1300,6 +1449,8 @@ def trace(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 
@@ -1314,11 +1465,14 @@ def dryrun(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print a dry-run notice via the default emitter.
 
-    See `Emitter.dryrun` for full kwarg semantics including `tag`/`right_tag`.
+    See `Emitter.dryrun` for full kwarg semantics including `tag`/`right_tag`
+    and `exception`/`show_locals`.
     """
     _default.dryrun(
         message,
@@ -1329,6 +1483,8 @@ def dryrun(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 
@@ -1343,11 +1499,14 @@ def warning(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print warning output via the default emitter.
 
-    See `Emitter.warning` for full kwarg semantics including `tag`/`right_tag`.
+    See `Emitter.warning` for full kwarg semantics including `tag`/`right_tag`
+    and `exception`/`show_locals`.
     """
     _default.warning(
         message,
@@ -1358,6 +1517,8 @@ def warning(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 
@@ -1372,11 +1533,14 @@ def error(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print error output via the default emitter.
 
-    See `Emitter.error` for full kwarg semantics including `tag`/`right_tag`.
+    See `Emitter.error` for full kwarg semantics including `tag`/`right_tag`
+    and `exception`/`show_locals`.
     """
     _default.error(
         message,
@@ -1387,6 +1551,8 @@ def error(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 
@@ -1401,12 +1567,14 @@ def critical(  # noqa: PLR0913
     marker: str | None = None,
     tag: str | None = None,
     right_tag: str | None = None,
+    exception: BaseException | bool = False,
+    show_locals: bool = False,
     **kwargs: Any,
 ) -> None:
     """Print critical output via the default emitter. Always shown, even when `quiet`.
 
     Severity-only; does not raise. See `Emitter.critical` for full semantics
-    including `tag`/`right_tag`.
+    including `tag`/`right_tag` and `exception`/`show_locals`.
     """
     _default.critical(
         message,
@@ -1417,6 +1585,8 @@ def critical(  # noqa: PLR0913
         marker=marker,
         tag=tag,
         right_tag=right_tag,
+        exception=exception,
+        show_locals=show_locals,
         **kwargs,
     )
 

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -279,12 +279,18 @@ def _format_exception_for_logfile(exception: BaseException | bool) -> list[str] 
     Returns None when there's nothing to attach (`exception=False` or
     `exception=True` with no active exception). The resulting strings have no
     color codes; the logfile path strips Rich coloring anyway.
+
+    The returned strings are pre-escaped for Rich markup so that any bracket
+    characters in the exception message survive the logfile path's
+    string-as-markup rendering in `_render_details_to_lines`. Without escaping,
+    a message like `KeyError: ['missing_key']` would have the bracketed portion
+    silently stripped by Rich's markup parser.
     """
     exc = _resolve_exception(exception)
     if exc is None:
         return None
     return [
-        line.rstrip("\n")
+        escape(line.rstrip("\n"))
         for chunk in _traceback.format_exception(type(exc), exc, exc.__traceback__)
         for line in chunk.splitlines()
     ]

--- a/tests/pp/test_exception.py
+++ b/tests/pp/test_exception.py
@@ -1,0 +1,278 @@
+"""Tests for the exception= kwarg on level methods."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nclutils import pp
+from nclutils.pp.constants import Verbosity
+from nclutils.pp.emitter import set_default
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .conftest import RecordingEmitterFactory
+
+
+def _capture(exc_cls: type[BaseException], message: str) -> BaseException:
+    """Raise `exc_cls(message)`, catch it, and return the captured instance with a traceback."""
+    try:
+        raise exc_cls(message)  # noqa: TRY301 -- inner raise IS the test setup; cannot abstract further
+    except BaseException as exc:  # noqa: BLE001 -- intentional broad catch to relay any subtype
+        return exc
+
+
+def _raises_with_local() -> None:
+    """Raise RuntimeError after binding a distinctive local for show_locals dump tests."""
+    local_marker = "sentinel_value_42"  # noqa: F841 -- inspected via show_locals dump
+    msg = "boom"
+    raise RuntimeError(msg)
+
+
+class TestExceptionInstance:
+    """exception=<BaseException instance> appends a Traceback to the rendered output."""
+
+    def test_exception_instance_renders_traceback(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify passing an exception instance renders a Rich Traceback below the message."""
+        # Given an emitter wired to recording stderr and a captured exception
+        e, _, err = make_recording_emitter()
+        captured = _capture(RuntimeError, "403 Forbidden")
+
+        # When error is called with the exception instance
+        e.error("upload failed", exception=captured)
+
+        # Then both the message and the traceback identifying info appear
+        text = err.export_text()
+        assert "upload failed" in text
+        assert "RuntimeError" in text
+        assert "403 Forbidden" in text
+
+    def test_exception_instance_appended_after_existing_details(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify the traceback is appended as the final detail item, after any caller details."""
+        # Given an emitter and a captured exception with caller-supplied details
+        e, _, err = make_recording_emitter()
+        captured = _capture(RuntimeError, "boom")
+
+        # When error is called with both details and an exception
+        e.error("failed", details=["target: prod"], exception=captured)
+
+        # Then the original detail and the traceback both render
+        text = err.export_text()
+        assert "target: prod" in text
+        assert "RuntimeError" in text
+        # Traceback should appear after the caller-supplied detail in the stream
+        assert text.index("target: prod") < text.index("RuntimeError")
+
+
+class TestExceptionTrue:
+    """exception=True grabs sys.exc_info() inside an except block."""
+
+    def test_exception_true_inside_except_block(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify exception=True inside an except block uses sys.exc_info()."""
+        # Given an emitter wired to recording stderr
+        e, _, err = make_recording_emitter()
+
+        # When error is called with exception=True inside an except block
+        try:
+            msg = "boom"
+            raise ValueError(msg)  # noqa: TRY301 -- direct raise required to populate sys.exc_info
+        except ValueError:
+            e.error("operation failed", exception=True)
+
+        # Then the traceback for the active exception appears
+        text = err.export_text()
+        assert "ValueError" in text
+        assert "boom" in text
+
+    def test_exception_true_outside_except_is_noop(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify exception=True outside an except block is a silent no-op."""
+        # Given an emitter wired to recording stderr (no active exception)
+        e, _, err = make_recording_emitter()
+
+        # When error is called with exception=True outside any except block
+        e.error("operation failed", exception=True)
+
+        # Then the message renders but no Traceback frame appears
+        text = err.export_text()
+        assert "operation failed" in text
+        assert "Traceback" not in text
+
+    def test_exception_true_outside_except_has_no_logfile_traceback(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify exception=True outside an except block leaves the logfile traceback-free."""
+        # Given an emitter with a logfile and no active exception
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When error is called with exception=True outside any except block
+        e.error("operation failed", exception=True)
+
+        # Then the logfile records the message but no traceback markers
+        contents = logfile.read_text()
+        assert "operation failed" in contents
+        assert "Traceback" not in contents
+
+
+class TestShowLocals:
+    """show_locals flows through to Rich's Traceback for verbose dumps."""
+
+    def test_show_locals_true_includes_local_variable(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify show_locals=True surfaces a frame's local variables in the rendered traceback."""
+        # Given an emitter and a function that raises with a distinctive local variable
+        e, _, err = make_recording_emitter()
+        try:
+            _raises_with_local()
+        except RuntimeError as exc:
+            captured = exc
+
+        # When error is called with show_locals=True
+        e.error("boom", exception=captured, show_locals=True)
+
+        # Then the local variable marker appears in the dumped traceback
+        text = err.export_text()
+        assert "local_marker" in text
+        assert "sentinel_value_42" in text
+
+
+class TestExceptionLogfile:
+    """Tracebacks are written to the logfile as continuation lines."""
+
+    def test_traceback_in_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify the formatted traceback string is written to the logfile."""
+        # Given an emitter with a logfile and a captured exception
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+        captured = _capture(RuntimeError, "403 Forbidden")
+
+        # When error is called with the exception instance
+        e.error("upload failed", exception=captured)
+
+        # Then the logfile records both the message and the formatted traceback
+        contents = logfile.read_text()
+        assert "upload failed" in contents
+        assert "RuntimeError" in contents
+        assert "403 Forbidden" in contents
+        assert "Traceback (most recent call last)" in contents
+
+    def test_logfile_traceback_uses_parent_severity(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify each traceback continuation line is logged at the parent record's severity."""
+        # Given an emitter with a logfile and a captured exception
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+        captured = _capture(RuntimeError, "soft fail")
+
+        # When warning is called with the exception
+        e.warning("retrying", exception=captured)
+
+        # Then every traceback continuation line is tagged WARNING (not INFO)
+        contents = logfile.read_text()
+        traceback_lines = [line for line in contents.splitlines() if "RuntimeError" in line]
+        assert traceback_lines
+        for line in traceback_lines:
+            assert "WARNING" in line
+
+
+class TestExceptionAcrossLevels:
+    """exception= works on every level method."""
+
+    @pytest.mark.parametrize(
+        ("method", "to_stderr", "verbosity_needed"),
+        [
+            ("info", False, False),
+            ("success", False, False),
+            ("warning", True, False),
+            ("error", True, False),
+            ("critical", True, False),
+            ("debug", False, True),
+            ("trace", False, True),
+            ("dryrun", False, False),
+        ],
+    )
+    def test_exception_appears_on_each_level(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        method: str,
+        *,
+        to_stderr: bool,
+        verbosity_needed: bool,
+    ) -> None:
+        """Verify exception= renders a traceback on every level method."""
+        # Given an emitter with verbosity high enough to surface debug/trace
+        verbosity = Verbosity.TRACE if verbosity_needed else Verbosity.INFO
+        e, out, err = make_recording_emitter(verbosity=verbosity)
+        captured = _capture(ValueError, "boom")
+
+        # When the level method is called with the exception
+        getattr(e, method)("something happened", exception=captured)
+
+        # Then the traceback appears in the appropriate stream
+        target_text = err.export_text() if to_stderr else out.export_text()
+        assert "ValueError" in target_text
+        assert "boom" in target_text
+
+
+class TestModuleLevelDelegation:
+    """Module-level functions forward exception/show_locals to the default emitter."""
+
+    @pytest.mark.usefixtures("isolated_default")
+    def test_module_level_error_forwards_exception(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify module-level pp.error() forwards exception= through."""
+        # Given an isolated default emitter swapped in
+        e, _, err = make_recording_emitter()
+        set_default(e)
+        captured = _capture(ValueError, "boom")
+
+        # When pp.error is called with an exception
+        pp.error("operation failed", exception=captured)
+
+        # Then the traceback appears in the recorded stderr
+        text = err.export_text()
+        assert "ValueError" in text
+        assert "boom" in text
+
+    @pytest.mark.usefixtures("isolated_default")
+    @pytest.mark.parametrize(
+        "method",
+        ["info", "success", "warning", "critical", "dryrun"],
+    )
+    def test_module_level_levels_forward_exception(
+        self, make_recording_emitter: RecordingEmitterFactory, method: str
+    ) -> None:
+        """Verify each module-level function forwards exception= to the default emitter."""
+        # Given an isolated default emitter swapped in
+        e, out, err = make_recording_emitter()
+        set_default(e)
+        captured = _capture(ValueError, "boom")
+
+        # When the matching module-level function is called with the exception
+        getattr(pp, method)("something happened", exception=captured)
+
+        # Then the traceback surfaces somewhere in the recorded output streams
+        combined = out.export_text() + err.export_text()
+        assert "ValueError" in combined
+        assert "boom" in combined

--- a/tests/pp/test_exception.py
+++ b/tests/pp/test_exception.py
@@ -31,6 +31,19 @@ def _raises_with_local() -> None:
     raise RuntimeError(msg)
 
 
+def _raises_with_hidden_local() -> None:
+    """Raise RuntimeError after binding a runtime-built local that must NOT appear without show_locals.
+
+    The marker is assembled from parts so the literal string is absent from the
+    visible source of the raising frame; Rich's traceback shows source lines
+    around the raise, and we want to confirm `show_locals=False` keeps the
+    runtime VALUE out, independent of the source rendering.
+    """
+    hidden = "".join(["hidden", "-", "marker", "-", "abc123"])  # noqa: F841, FLY002 -- runtime assembly keeps the literal out of the source frame Rich displays
+    msg = "boom"
+    raise RuntimeError(msg)
+
+
 class TestExceptionInstance:
     """exception=<BaseException instance> appends a Traceback to the rendered output."""
 
@@ -148,6 +161,62 @@ class TestShowLocals:
         assert "local_marker" in text
         assert "sentinel_value_42" in text
 
+    def test_show_locals_false_excludes_local_variables(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify show_locals=False (the default) does NOT include local variable values."""
+        # Given an emitter and a function that raises after binding a runtime-assembled local
+        e, _, err = make_recording_emitter()
+        try:
+            _raises_with_hidden_local()
+        except RuntimeError as exc:
+            captured = exc
+
+        # When error is called without show_locals (default False)
+        e.error("operation failed", exception=captured)
+
+        # Then the assembled runtime value of the local is absent from the rendered output
+        text = err.export_text()
+        assert "RuntimeError" in text
+        assert "hidden-marker-abc123" not in text
+
+
+class TestExceptionFalseDefault:
+    """exception=False (the default) emits no traceback."""
+
+    def test_exception_false_no_traceback_in_console(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify exception=False produces no traceback in console output."""
+        # Given an emitter wired to recording stderr
+        e, _, err = make_recording_emitter()
+
+        # When error is called with the default exception=False
+        e.error("plain message")
+
+        # Then no traceback header text appears
+        text = err.export_text()
+        assert "plain message" in text
+        assert "Traceback" not in text
+
+    def test_exception_false_no_traceback_in_logfile(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify exception=False produces no traceback in the logfile."""
+        # Given an emitter with a logfile
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When error is called with the default exception=False
+        e.error("plain message")
+
+        # Then no traceback markers appear in the logfile
+        contents = logfile.read_text()
+        assert "plain message" in contents
+        assert "Traceback" not in contents
+
 
 class TestExceptionLogfile:
     """Tracebacks are written to the logfile as continuation lines."""
@@ -193,6 +262,33 @@ class TestExceptionLogfile:
         assert traceback_lines
         for line in traceback_lines:
             assert "WARNING" in line
+
+    def test_logfile_preserves_brackets_in_exception_message(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify the logfile preserves bracket characters in exception messages.
+
+        Plain stdlib traceback strings flow through the logfile path that
+        treats string details as Rich markup. Without escaping, an exception
+        message containing brackets like KeyError: ['missing_key'] would have
+        the bracketed portion silently stripped.
+        """
+        # Given an emitter with a logfile
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When an exception with brackets in its message is logged
+        try:
+            msg = "['missing_key']"
+            raise KeyError(msg)  # noqa: TRY301 -- inline raise required to populate the traceback
+        except KeyError as exc:
+            e.error("lookup failed", exception=exc)
+
+        # Then the bracketed substring survives in the logfile
+        contents = logfile.read_text()
+        assert "missing_key" in contents
 
 
 class TestExceptionAcrossLevels:
@@ -257,15 +353,28 @@ class TestModuleLevelDelegation:
 
     @pytest.mark.usefixtures("isolated_default")
     @pytest.mark.parametrize(
-        "method",
-        ["info", "success", "warning", "critical", "dryrun"],
+        ("method", "verbosity_needed"),
+        [
+            ("info", False),
+            ("success", False),
+            ("warning", False),
+            ("critical", False),
+            ("dryrun", False),
+            ("debug", True),
+            ("trace", True),
+        ],
     )
     def test_module_level_levels_forward_exception(
-        self, make_recording_emitter: RecordingEmitterFactory, method: str
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        method: str,
+        *,
+        verbosity_needed: bool,
     ) -> None:
         """Verify each module-level function forwards exception= to the default emitter."""
-        # Given an isolated default emitter swapped in
-        e, out, err = make_recording_emitter()
+        # Given an isolated default emitter swapped in (TRACE verbosity for debug/trace)
+        verbosity = Verbosity.TRACE if verbosity_needed else Verbosity.INFO
+        e, out, err = make_recording_emitter(verbosity=verbosity)
         set_default(e)
         captured = _capture(ValueError, "boom")
 


### PR DESCRIPTION
## Summary
- New `exception=` and `show_locals=` kwargs on every level method (`info`, `success`, `warning`, `error`, `critical`, `debug`, `trace`, `dryrun`) on both the `Emitter` class and the module-level functions.
- Accepts a `BaseException` instance or `True` (uses `sys.exc_info()`); outside an `except` block, `True` is a silent no-op matching `logging.exception()` semantics.
- Traceback rendered as a Rich `Traceback` inside the existing details tree (final detail item, picks up the `└─` connector automatically).
- Formatted traceback also written to the logfile as continuation lines at the parent record's severity, so level filters drop the message and traceback together.

## Test plan
- [x] `duty test` passes (412 tests, 22 new in `tests/pp/test_exception.py`)
- [x] `duty lint` passes (ruff, ruff format, mypy, typos, prek hooks, committed)
- [x] `uv run scripts/pp_demo.py` shows the new "Exceptions" section: instance form, `exception=True`, and `show_locals=True` all render with tracebacks beneath their messages