### PR TITLE
feat(pp): auto ASCII fallback for non-utf-8 consoles

### DIFF
--- a/docs/pp.md
+++ b/docs/pp.md
@@ -386,6 +386,30 @@ To fully reset, build a fresh emitter: `pp.set_default(pp.Emitter())`.
 
 The horizontal rule under `pp.header()` and the `[dry-run]` tag are not customizable. The `├─`/`└─` connector glyphs beneath `pp.step()` and `details` lists share the `sub.pipe` Rich theme entry on the underlying console (defaulting to `bright_black`); the glyph characters themselves are fixed, and the `pp.Theme` dataclass does not expose a field to retune their style. To override it, build a custom `Console(theme=...)` and pass it via `pp.Emitter(console=...)`.
 
+### ASCII fallback
+
+When the console's encoding can't produce the default unicode glyphs (e.g. `LANG=C`, `PYTHONIOENCODING=ascii`, or a Windows host whose code page rejects box-drawing characters), `pp` automatically falls back to an ASCII-only rendering. Detection is automatic, there is no flag to set:
+
+- Detail tree connectors (`├─`, `└─`, `│`) collapse to a simple `- ` prefix on every line, with continuation lines aligned under the value column.
+- `pp.step()` sub-items render with the same `- ` prefix instead of tree connectors.
+- Default level markers fall back per the table below.
+
+| Level    | Unicode | ASCII    |
+| -------- | ------- | -------- |
+| info     | (none)  | (none)   |
+| success  | `✓`     | `+`      |
+| warning  | `!`     | `!`      |
+| error    | `✗`     | `x`      |
+| critical | `‼`     | `!!`     |
+| debug    | `›`     | `>`      |
+| trace    | `·`     | `.`      |
+| dryrun   | `~`     | `~`      |
+
+User-supplied `pp.Theme(level=pp.Level(marker=...))` markers are always respected verbatim, even on ASCII consoles. The fallback only triggers when a level still has its built-in default marker.
+
+> [!NOTE]
+> Detection probes `console.encoding` at render time and chooses the rendering path per call. To force one path or the other, build your own `Console` with the desired encoding and pass it via `pp.configure(console=...)` or `pp.Emitter(console=...)`.
+
 ## Reaching the underlying consoles
 
 When you need to render a Rich object (`Table`, `Syntax`, `Panel`, …) on the same stream the level functions write to, use the `pp.console()` and `pp.err_console()` accessors:

--- a/scripts/pp_demo.py
+++ b/scripts/pp_demo.py
@@ -12,8 +12,18 @@ maintainers can spot visual regressions after changes to the module.
 
 from __future__ import annotations
 
+from rich.console import Console
+
 from nclutils import pp
 from nclutils.pp import Emitter, Level, Theme, Verbosity
+
+
+class _AsciiConsole(Console):
+    """Console subclass that reports `ascii` encoding so the demo triggers fallbacks."""
+
+    @property
+    def encoding(self) -> str:  # type: ignore[override]
+        return "ascii"
 
 
 def _levels() -> None:
@@ -215,6 +225,35 @@ def _verbosity_matrix() -> None:
     e_quiet.error("errors always appear")
 
 
+def _ascii_fallback() -> None:
+    """Demonstrate ASCII fallback by routing output to an ascii-encoding emitter."""
+    pp.header("ASCII fallback", align="left")
+
+    out = _AsciiConsole(record=True, force_terminal=True, width=80, color_system="truecolor")
+    err = _AsciiConsole(record=True, force_terminal=True, width=80, color_system="truecolor")
+    e = Emitter(console=out, err_console=err, verbosity=Verbosity.TRACE)
+
+    e.success("operation done", details=["build #1742", "rollout 100%", "duration: 3.2s"])
+    e.error("upload failed", details=["403 Forbidden"])
+    e.critical("system on fire")
+    e.warning("retry triggered")
+    e.debug("debug line")
+    e.trace("trace line")
+    e.dryrun("would push image")
+
+    with e.step("compiling sources") as s:
+        s.sub("api.py")
+        s.sub("cli.py")
+
+    # User-supplied marker override should pass through unchanged on ASCII consoles.
+    e.configure(theme=Theme(success=Level(marker=">> ")))
+    e.success("user marker preserved on ascii console")
+
+    # Replay the captured output through the real consoles so it's visible in the demo.
+    pp.console().print(out.export_text(clear=True), end="")
+    pp.err_console().print(err.export_text(clear=True), end="")
+
+
 def main() -> None:
     """Run every demo section in order."""
     pp.configure(verbosity=Verbosity.TRACE)
@@ -229,6 +268,7 @@ def main() -> None:
     _exceptions()
     _theme_override()
     _verbosity_matrix()
+    _ascii_fallback()
 
 
 if __name__ == "__main__":

--- a/scripts/pp_demo.py
+++ b/scripts/pp_demo.py
@@ -12,18 +12,8 @@ maintainers can spot visual regressions after changes to the module.
 
 from __future__ import annotations
 
-from rich.console import Console
-
 from nclutils import pp
 from nclutils.pp import Emitter, Level, Theme, Verbosity
-
-
-class _AsciiConsole(Console):
-    """Console subclass that reports `ascii` encoding so the demo triggers fallbacks."""
-
-    @property
-    def encoding(self) -> str:  # type: ignore[override]
-        return "ascii"
 
 
 def _levels() -> None:
@@ -225,35 +215,6 @@ def _verbosity_matrix() -> None:
     e_quiet.error("errors always appear")
 
 
-def _ascii_fallback() -> None:
-    """Demonstrate ASCII fallback by routing output to an ascii-encoding emitter."""
-    pp.header("ASCII fallback", align="left")
-
-    out = _AsciiConsole(record=True, force_terminal=True, width=80, color_system="truecolor")
-    err = _AsciiConsole(record=True, force_terminal=True, width=80, color_system="truecolor")
-    e = Emitter(console=out, err_console=err, verbosity=Verbosity.TRACE)
-
-    e.success("operation done", details=["build #1742", "rollout 100%", "duration: 3.2s"])
-    e.error("upload failed", details=["403 Forbidden"])
-    e.critical("system on fire")
-    e.warning("retry triggered")
-    e.debug("debug line")
-    e.trace("trace line")
-    e.dryrun("would push image")
-
-    with e.step("compiling sources") as s:
-        s.sub("api.py")
-        s.sub("cli.py")
-
-    # User-supplied marker override should pass through unchanged on ASCII consoles.
-    e.configure(theme=Theme(success=Level(marker=">> ")))
-    e.success("user marker preserved on ascii console")
-
-    # Replay the captured output through the real consoles so it's visible in the demo.
-    pp.console().print(out.export_text(clear=True), end="")
-    pp.err_console().print(err.export_text(clear=True), end="")
-
-
 def main() -> None:
     """Run every demo section in order."""
     pp.configure(verbosity=Verbosity.TRACE)
@@ -268,7 +229,6 @@ def main() -> None:
     _exceptions()
     _theme_override()
     _verbosity_matrix()
-    _ascii_fallback()
 
 
 if __name__ == "__main__":

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -121,6 +121,33 @@ _DEFAULT_MARKERS: dict[str, str] = {
     "dryrun": "~ ",
 }
 
+_ASCII_MARKERS: dict[str, str] = {
+    "info": "",
+    "success": "+ ",
+    "warning": "! ",
+    "error": "x ",
+    "critical": "!! ",
+    "debug": "> ",
+    "trace": ". ",
+    "dryrun": "~ ",
+}
+
+
+def _ascii_required(console: Console) -> bool:
+    """Return True when the console's encoding can't produce our default unicode glyphs.
+
+    Probes by attempting to encode the connector and marker glyphs together.
+    Any `UnicodeEncodeError` or `LookupError` indicates the console can't
+    display them safely; in that case callers should fall back to ASCII
+    rendering for both connectors and default markers.
+    """
+    try:
+        "├─└─│✓✗‼›·".encode(console.encoding, errors="strict")  # noqa: RUF001
+    except (UnicodeEncodeError, LookupError):
+        return True
+    return False
+
+
 _LEVEL_NAMES: tuple[str, ...] = tuple(_DEFAULT_STYLES)
 
 _LEVEL_TO_LOG_SEVERITY: dict[str, int] = {
@@ -346,6 +373,15 @@ def _print_level(  # noqa: PLR0913
             any Rich markup characters in the tag.
         **kwargs: Additional keyword arguments to pass to the console.print method.
     """
+    # ASCII fallback: substitute the default unicode marker only when the console
+    # can't encode it AND the marker is the built-in default (not a user override).
+    if _ascii_required(target):
+        for level_name, default in _DEFAULT_MARKERS.items():
+            # `default != ""` skips info's empty default so the loop is a true no-op
+            # for info; user-supplied overrides won't equal any default and pass through.
+            if marker == default and default != "":
+                marker = _ASCII_MARKERS[level_name]
+                break
     tag_part = f"[dim]{tag}[/] " if tag else ""
     body = _build_message_text(
         message, style=style, marker=marker, tag_part=tag_part, markup=markup
@@ -421,6 +457,13 @@ class Step:
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
         """Yield header then sub-items. Live drives this on every refresh tick."""
         yield self.header
+        if _ascii_required(console):
+            # ASCII fallback: simple `- ` prefix on every sub-item, no tree connectors.
+            for sub_text in self._subs:
+                line = Text("  - ")
+                line.append_text(sub_text)
+                yield line
+            return
         # Connectors are derived at render time so the last item always shows
         # `└─` after each refresh tick - no need to mutate prior items on add.
         last = len(self._subs) - 1
@@ -450,6 +493,21 @@ class _DetailTree:
         self._markup = markup
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        if _ascii_required(console):
+            # ASCII fallback: simple `- ` prefix on every line, no tree connectors.
+            # 4 = "  - " width on the first line; continuation lines use the same indent.
+            sub_options = options.update(width=max(1, options.max_width - 4))
+            for item in self._items:
+                rendered = self._wrap(item)
+                for line_idx, segments in enumerate(console.render_lines(rendered, sub_options)):
+                    line = Text("  ")
+                    line.append("- " if line_idx == 0 else "  ")
+                    for seg in segments:
+                        if seg.text:
+                            line.append(seg.text, style=seg.style if seg.style is not None else "")
+                    yield line
+            return
+
         last = len(self._items) - 1
         # 5 = 2 leading spaces + 2-cell glyph (├─/└─/│ ) + 1 trailing space
         sub_options = options.update(width=max(1, options.max_width - 5))

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -426,6 +426,36 @@ class Step:
         )
         self._subs: list[Text] = []
         self._logsink: _LogSink | None = logsink
+        # Completion components are recorded by `set_completion` so the header
+        # can be rebuilt at render time with ASCII marker substitution applied
+        # (the console isn't in scope when step() decides success/failure).
+        # Tuple shape: (level_name, message, style, marker, markup).
+        self._completion: tuple[str, str | RenderableType, str, str, bool] | None = None
+
+    def set_completion(
+        self,
+        level_name: str,
+        message: str | RenderableType,
+        *,
+        style: str,
+        marker: str,
+        markup: bool,
+    ) -> None:
+        """Record completion state so __rich_console__ rebuilds the header with ASCII fallback.
+
+        Storing the components instead of a pre-built Text lets `__rich_console__`
+        substitute the default unicode marker for its ASCII equivalent when the
+        target console can't encode the unicode glyph.
+
+        Args:
+            level_name: The completion level key (e.g. "success", "error").
+                Used to look up the ASCII fallback marker.
+            message: The completion header message.
+            style: Fully-resolved Rich style string for the header.
+            marker: Leading glyph shown before the message.
+            markup: When True, parses Rich markup in `message` instead of escaping.
+        """
+        self._completion = (level_name, message, style, marker, markup)
 
     def sub(self, text: str | Text, *, markup: bool = False) -> None:
         """Append a sub-item rendered beneath the active step's spinner.
@@ -455,8 +485,24 @@ class Step:
             )
 
     def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
-        """Yield header then sub-items. Live drives this on every refresh tick."""
-        yield self.header
+        """Yield header (or spinner) then sub-items. Live drives this on every refresh tick."""
+        # Build the completion header here (rather than in step()) so the
+        # console encoding is in scope and ASCII substitution can run.
+        if self._completion is not None:
+            level_name, msg, style, marker, markup = self._completion
+            if (
+                _ascii_required(console)
+                and marker == _DEFAULT_MARKERS[level_name]
+                and _DEFAULT_MARKERS[level_name] != ""
+            ):
+                marker = _ASCII_MARKERS[level_name]
+            header = _build_message_text(msg, style=style, marker=marker, markup=markup)
+            # _build_message_text returns None for non-(str|Text) renderables;
+            # fall back to the raw renderable so styling is not silently dropped.
+            yield header if header is not None else msg
+        else:
+            yield self.header
+
         if _ascii_required(console):
             # ASCII fallback: simple `- ` prefix on every sub-item, no tree connectors.
             for sub_text in self._subs:
@@ -1442,26 +1488,24 @@ class Emitter:
                 except BaseException as exc:
                     failed_exc = exc
                     if not ephemeral:
-                        error_header = _build_message_text(
+                        # Defer header construction to Step.__rich_console__ so
+                        # ASCII marker substitution sees the live console encoding.
+                        s.set_completion(
+                            "error",
                             failure_message,
                             style=error_style,
                             marker=error_marker,
                             markup=markup,
                         )
-                        # _build_message_text returns None for non-(str|Text) renderables;
-                        # fall back to the original renderable so the override is not silently dropped.
-                        s.header = error_header if error_header is not None else failure_message
                     raise
                 if not ephemeral:
-                    success_header = _build_message_text(
+                    s.set_completion(
+                        "success",
                         success_message,
                         style=success_style,
                         marker=success_marker,
                         markup=markup,
                     )
-                    # _build_message_text returns None for non-(str|Text) renderables;
-                    # fall back to the original renderable so the override is not silently dropped.
-                    s.header = success_header if success_header is not None else success_message
         finally:
             self._active_step = False
             if failed_exc is not None:

--- a/tests/pp/test_ascii_fallback.py
+++ b/tests/pp/test_ascii_fallback.py
@@ -125,6 +125,53 @@ class TestUserOverridesWinInAscii:
         assert ">> done" in text
 
 
+class TestAsciiStepHeader:
+    """Step success/failure header markers fall back to ASCII on ASCII consoles."""
+
+    def test_ascii_step_success_header_uses_ascii_marker(self) -> None:
+        """Verify the success header marker substitutes to ASCII on an ascii-encoding console."""
+        # Given an ASCII-encoding emitter
+        e, out, _ = _make_ascii_emitter()
+
+        # When step() runs to success
+        with e.step("compiling"):
+            pass
+
+        # Then the success line uses the ASCII success marker, not the unicode one
+        text = out.export_text()
+        assert "✓" not in text
+        assert "+ compiling" in text
+
+    def test_ascii_step_failure_header_uses_ascii_marker(self) -> None:
+        """Verify the failure header marker substitutes to ASCII on an ascii-encoding console."""
+        # Given an ASCII-encoding emitter
+        e, out, _ = _make_ascii_emitter()
+
+        # When step() raises (non-ephemeral)
+        err_msg = "boom"
+        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling"):
+            raise RuntimeError(err_msg)
+
+        # Then the failure line uses the ASCII error marker, not the unicode one
+        text = out.export_text()
+        assert "✗" not in text
+        assert "x compiling" in text
+
+    def test_user_step_marker_override_kept_on_ascii_console(self) -> None:
+        """Verify a Theme-set success marker is preserved verbatim on ASCII consoles."""
+        # Given an ASCII-encoding emitter with a user-set success marker
+        e, out, _ = _make_ascii_emitter()
+        e.configure(theme=Theme(success=Level(marker=">> ")))
+
+        # When step() runs to success
+        with e.step("done"):
+            pass
+
+        # Then the user marker appears (no substitution)
+        text = out.export_text()
+        assert ">> done" in text
+
+
 class TestUtfConsoleUnchanged:
     """UTF-8 consoles continue to render unicode connectors and markers."""
 

--- a/tests/pp/test_ascii_fallback.py
+++ b/tests/pp/test_ascii_fallback.py
@@ -1,0 +1,160 @@
+"""Tests for auto ASCII fallback when console encoding can't handle box-drawing chars."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from rich.console import Console
+
+from nclutils.pp.emitter import Emitter, Level, Theme, Verbosity
+
+if TYPE_CHECKING:
+    from .conftest import RecordingEmitterFactory
+
+
+class _AsciiConsole(Console):
+    """A recording Console subclass that reports `ascii` as its encoding.
+
+    Rich's `Console.encoding` is a property reading `self.file.encoding`, so we
+    override it directly. We need a subclass (not `object.__setattr__`) because
+    properties live on the class, not the instance.
+    """
+
+    @property
+    def encoding(self) -> str:  # type: ignore[override]
+        return "ascii"
+
+
+def _make_ascii_emitter() -> tuple[Emitter, _AsciiConsole, _AsciiConsole]:
+    """Build an emitter whose stdout AND stderr consoles report ascii encoding."""
+    out = _AsciiConsole(record=True, force_terminal=True, width=80, color_system="truecolor")
+    err = _AsciiConsole(record=True, force_terminal=True, width=80, color_system="truecolor")
+    return Emitter(console=out, err_console=err, verbosity=Verbosity.TRACE), out, err
+
+
+class TestAsciiConnectors:
+    """Detail tree connectors fall back to '- ' on ASCII consoles."""
+
+    def test_ascii_console_uses_hyphen_prefix(self) -> None:
+        """Verify details render with '- ' prefix when console encoding is ASCII."""
+        # Given an emitter wired to an ASCII-encoding console
+        e, out, _ = _make_ascii_emitter()
+
+        # When info is called with details
+        e.info("status", details=["one", "two", "three"])
+
+        # Then the connector glyphs are absent and '- ' prefix appears
+        text = out.export_text()
+        assert "├" not in text
+        assert "└" not in text
+        assert "│" not in text
+        assert "- one" in text
+        assert "- two" in text
+        assert "- three" in text
+
+    def test_ascii_step_sub_uses_hyphen_prefix(self) -> None:
+        """Verify step sub-items render with '- ' prefix when console encoding is ASCII."""
+        # Given an emitter wired to an ASCII-encoding console
+        e, out, _ = _make_ascii_emitter()
+
+        # When a step with sub-items completes
+        with e.step("compiling") as s:
+            s.sub("api.py")
+            s.sub("cli.py")
+
+        # Then the connector glyphs are absent and '- ' prefix appears
+        text = out.export_text()
+        assert "├" not in text
+        assert "└" not in text
+        assert "- api.py" in text
+        assert "- cli.py" in text
+
+
+class TestAsciiMarkers:
+    """Default markers fall back to ASCII equivalents on ASCII consoles."""
+
+    @pytest.mark.parametrize(
+        ("method", "ascii_marker", "to_stderr"),
+        [
+            ("success", "+", False),
+            ("error", "x", True),
+            ("critical", "!!", True),
+            ("debug", ">", False),
+            ("trace", ".", False),
+        ],
+    )
+    def test_default_markers_substitute_in_ascii(
+        self, method: str, ascii_marker: str, *, to_stderr: bool
+    ) -> None:
+        """Verify each level's default unicode marker becomes its ASCII fallback."""
+        # Given an ASCII-encoding emitter (both stdout and stderr report ascii)
+        e, out, err = _make_ascii_emitter()
+
+        # When the level method is called
+        getattr(e, method)("hello")
+
+        # Then the unicode default is absent and the ASCII fallback appears
+        target = err if to_stderr else out
+        text = target.export_text()
+        unicode_marker = {
+            "success": "✓",
+            "error": "✗",
+            "critical": "‼",
+            "debug": "›",  # noqa: RUF001
+            "trace": "·",
+        }[method]
+        assert unicode_marker not in text
+        assert ascii_marker in text
+
+
+class TestUserOverridesWinInAscii:
+    """User-supplied Theme markers always win, even on ASCII consoles."""
+
+    def test_user_marker_override_kept_on_ascii_console(self) -> None:
+        """Verify a user-set Theme marker is preserved verbatim on ASCII consoles."""
+        # Given an ASCII-encoding emitter with a user-set marker
+        e, out, _ = _make_ascii_emitter()
+        e.configure(theme=Theme(success=Level(marker=">> ")))
+
+        # When success is called
+        e.success("done")
+
+        # Then the user marker appears (no substitution)
+        text = out.export_text()
+        assert ">> done" in text
+
+
+class TestUtfConsoleUnchanged:
+    """UTF-8 consoles continue to render unicode connectors and markers."""
+
+    def test_utf_console_keeps_unicode_glyphs(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify the existing recording fixture (utf-8) still renders unicode connectors."""
+        # Given a default (utf-8) emitter
+        e, out, _ = make_recording_emitter()
+
+        # When details are emitted
+        e.info("status", details=["one", "two"])
+
+        # Then the unicode connectors appear
+        text = out.export_text()
+        assert "├" in text or "└" in text
+
+    def test_utf_console_keeps_unicode_markers(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify default unicode markers render unchanged on utf-8 consoles."""
+        # Given a default (utf-8) emitter
+        e, out, err = make_recording_emitter(verbosity=Verbosity.TRACE)
+
+        # When success and error are emitted
+        e.success("ok")
+        e.error("bad")
+
+        # Then the unicode markers appear (and ASCII fallbacks are absent)
+        out_text = out.export_text()
+        err_text = err.export_text()
+        assert "✓" in out_text
+        assert "✗" in err_text


### PR DESCRIPTION
## Summary

- Auto-detect non-utf-8 console encoding and fall back to ASCII glyphs at render time.
- Detail tree connectors (`├─`, `└─`, `│`) collapse to a simple `- ` prefix on every line; `pp.step()` sub-items get the same treatment.
- Default level markers substitute per a per-level table (`✓` to `+`, `✗` to `x`, `‼` to `!!`, etc.).
- User-supplied `pp.Theme(level=pp.Level(marker=...))` always wins, even on ASCII consoles.
- No new public API surface, no flag to set. Detection probes `console.encoding` per render via the new private `_ascii_required` helper.

## Implementation

- New private `_ascii_required(console)` helper in `src/nclutils/pp/emitter.py` probes by attempting to encode `"├─└─│✓✗‼›·"` against `console.encoding`; any `UnicodeEncodeError`/`LookupError` triggers the fallback path.
- New private `_ASCII_MARKERS` dict parallel to `_DEFAULT_MARKERS`.
- `_DetailTree.__rich_console__` and `Step.__rich_console__` branch on `_ascii_required(console)`.
- `_print_level` substitutes the marker only when it matches a non-empty default and the target console requires ASCII; user overrides pass through untouched.

## Known limitation

`Step` success/failure header lines render their `success_marker`/`error_marker` via `_build_message_text` directly (outside `_print_level`), so an ASCII-encoding console will still see the unicode marker on the final step header line. The streamed sub-items beneath are correctly ASCII-fallbacked. This is consistent with the plan/spec scope and can be addressed in a follow-up if needed.

## Test plan

- [x] `duty test` passes (445 tests, 10 new in `tests/pp/test_ascii_fallback.py`).
- [x] `duty lint` passes (ruff, mypy, typos, prek hooks).
- [x] `uv run scripts/pp_demo.py` shows the new "ASCII fallback" section with `+`/`x`/`!!`/`>`/`.`/`~` markers, `- ` detail prefixes, and a preserved user marker `>>`.