### PR TITLE
feat(sh): log every run_command invocation at DEBUG

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -348,7 +348,7 @@ Every branch helper returns or accepts short branch names (no `refs/heads/` pref
 
 ### Runner
 
-`run_git(*args, cwd=None, env=None, input=None, timeout=None, exclude_regex=None, stream=False, check=True, okay_codes=(0,)) -> CompletedCommand` is the single subprocess entry point used by every other helper in the module. It prepends `git` to `args`, logs the invocation at `DEBUG`, and forwards every option to `nclutils.sh.run_command`. Returns a `CompletedCommand` (see [shell_commands.md](shell_commands.md)).
+`run_git(*args, cwd=None, env=None, input=None, timeout=None, exclude_regex=None, stream=False, check=True, okay_codes=(0,)) -> CompletedCommand` is the single subprocess entry point used by every other helper in the module. It prepends `git` to `args` and forwards every option to `nclutils.sh.run_command`. Returns a `CompletedCommand` (see [shell_commands.md](shell_commands.md)).
 
 ```python
 from nclutils.git import run_git
@@ -400,16 +400,16 @@ See [docs/shell_commands.md](shell_commands.md) for the full `ShellCommandError`
 
 ## Diagnostic logging
 
-`nclutils.git` emits `DEBUG` messages through stdlib `logging` under the `nclutils.git` logger. Every git invocation is logged. To see them:
+Every git invocation is logged at `DEBUG` by `nclutils.sh.run_command`, which is what `run_git` delegates to. The records arrive under the `nclutils.sh` logger, not `nclutils.git`:
 
 ```python
 import logging
 
-logging.getLogger("nclutils.git").setLevel(logging.DEBUG)
+logging.getLogger("nclutils.sh").setLevel(logging.DEBUG)
 logging.basicConfig()
 ```
 
-This is independent of `nclutils.pp`. The git module never writes to the console directly; for visible progress on long-running commands, pass `stream=True` to the helper instead.
+See [shell_commands.md](shell_commands.md#diagnostic-logging) for what the records contain. This is independent of `nclutils.pp`; the git module never writes to the console directly. For visible progress on long-running commands, pass `stream=True` to the helper instead.
 
 ## API reference
 

--- a/docs/shell_commands.md
+++ b/docs/shell_commands.md
@@ -250,6 +250,19 @@ else:
     print("ripgrep not installed; falling back to grep")
 ```
 
+## Diagnostic logging
+
+`run_command` emits a `DEBUG` record for every invocation through stdlib `logging` under the `nclutils.sh` logger. The message is the final argv (after any `sudo=True` prepend), formatted with `shlex.join` so it can be pasted back into a shell. Nothing is logged about stdout, stderr, or the return code; the returned `CompletedCommand` already carries those.
+
+```python
+import logging
+
+logging.getLogger("nclutils.sh").setLevel(logging.DEBUG)
+logging.basicConfig()
+```
+
+The logger is silent until the host application attaches a handler, so importing `nclutils.sh` never produces output on its own. This is independent of `nclutils.pp`. Anything built on top of `run_command` (including `nclutils.git.run_git`) inherits this logging for free; callers do not need to log invocations themselves.
+
 ## Migrating from the old API
 
 The previous `nclutils.sh` module was a thin wrapper around the third-party `sh` package. The new implementation uses stdlib `subprocess` directly.

--- a/src/nclutils/git/runner.py
+++ b/src/nclutils/git/runner.py
@@ -6,7 +6,6 @@ nclutils.git calls run_git rather than running subprocess directly.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from nclutils.sh import CompletedCommand, run_command
@@ -14,8 +13,6 @@ from nclutils.sh import CompletedCommand, run_command
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
-
-logger = logging.getLogger("nclutils.git")
 
 
 class NotARepoError(Exception):
@@ -35,11 +32,11 @@ def run_git(  # noqa: PLR0913
 ) -> CompletedCommand:
     """Run a git subcommand and return the structured result.
 
-    Thin prefix-and-log wrapper over :func:`nclutils.sh.run_command`.
-    Prepends ``git`` to ``args``, logs the invocation at DEBUG level under
-    the ``nclutils.git`` logger, and passes every other parameter through
-    verbatim. ``run_command`` handles cwd normalization (``Path.expanduser().resolve()``
-    plus ``is_dir()`` validation), so this layer does not re-resolve.
+    Thin prefix wrapper over :func:`nclutils.sh.run_command`. Prepends
+    ``git`` to ``args`` and passes every other parameter through verbatim.
+    ``run_command`` handles cwd normalization (``Path.expanduser().resolve()``
+    plus ``is_dir()`` validation) and logs each invocation at DEBUG under
+    the ``nclutils.sh`` logger, so this layer does not duplicate either.
 
     Args:
         *args: Git subcommand and arguments. ``run_git("status", "-s")``
@@ -69,7 +66,6 @@ def run_git(  # noqa: PLR0913
         nclutils.sh.ShellCommandTimeoutError: ``timeout`` exceeded.
     """
     argv = ["git", *args]
-    logger.debug(" ".join(argv))
     return run_command(
         argv,
         cwd=cwd,

--- a/src/nclutils/sh/shell_command.py
+++ b/src/nclutils/sh/shell_command.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -21,6 +23,8 @@ from .errors import (
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+
+logger = logging.getLogger("nclutils.sh")
 
 
 def which(cmd: str) -> Path | None:
@@ -96,6 +100,9 @@ def run_command(  # noqa: C901, PLR0912, PLR0913, PLR0915
     if sudo:
         final_argv = ["sudo", *final_argv]
     final_argv_tuple = tuple(final_argv)
+
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("%s", shlex.join(final_argv))
 
     resolved_cwd = _resolve_cwd(cwd)
     exclude_pattern = re.compile(exclude_regex) if exclude_regex else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Shared fixtures for nclutils tests."""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def sh_caplog(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    """Capture DEBUG-and-above records from `nclutils.sh`."""
+    caplog.set_level(logging.DEBUG, logger="nclutils.sh")
+    return caplog

--- a/tests/git/test_runner.py
+++ b/tests/git/test_runner.py
@@ -93,14 +93,16 @@ class TestRunGit:
         result = run_git("log", "-1", "--pretty=%an", cwd=repo)
         assert result.stdout.strip() == "EnvAuthor"
 
-    def test_logs_at_debug_level(self, repo: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """Verify run_git logs each invocation under nclutils.git at DEBUG."""
-        # Given: caplog set to capture nclutils.git at DEBUG
-        caplog.set_level(logging.DEBUG, logger="nclutils.git")
+    def test_logs_at_debug_level(self, repo: Path, sh_caplog: pytest.LogCaptureFixture) -> None:
+        """Verify run_git invocations surface through nclutils.sh and add no nclutils.git records."""
+        # Given: also capture the retired nclutils.git logger so a regression would show up
+        sh_caplog.set_level(logging.DEBUG, logger="nclutils.git")
 
-        # When: any call is made
+        # When
         run_git("status", cwd=repo)
 
-        # Then: at least one record contains 'git status'
-        messages = [r.getMessage() for r in caplog.records if r.name == "nclutils.git"]
-        assert any("git status" in m for m in messages)
+        # Then: the invocation surfaces under nclutils.sh, and the retired
+        # nclutils.git logger emits nothing.
+        sh_messages = [r.getMessage() for r in sh_caplog.records if r.name == "nclutils.sh"]
+        assert any("git status" in m for m in sh_messages)
+        assert not any(r.name == "nclutils.git" for r in sh_caplog.records)

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -425,6 +425,38 @@ class TestRunCommandCapture:
             assert result.cwd == tmp_path.resolve()
 
 
+class TestRunCommandLogging:
+    """Tests for the DEBUG logging emitted by run_command."""
+
+    @pytest.mark.parametrize(
+        ("argv", "expected"),
+        [
+            (["echo", "hello"], "echo hello"),
+            (["echo", "two words"], "'two words'"),
+        ],
+    )
+    def test_logs_argv_at_debug(
+        self, sh_caplog: pytest.LogCaptureFixture, argv: list[str], expected: str
+    ) -> None:
+        """Verify run_command emits the shlex-joined argv at DEBUG under nclutils.sh."""
+        # When
+        run_command(argv)
+
+        # Then
+        messages = [r.getMessage() for r in sh_caplog.records if r.name == "nclutils.sh"]
+        assert any(expected in m for m in messages)
+
+    def test_logs_before_subprocess_spawn(self, sh_caplog: pytest.LogCaptureFixture) -> None:
+        """Verify the invocation is logged even when the executable is missing."""
+        # When: a non-existent binary is invoked (raises before any output)
+        with pytest.raises(ShellCommandNotFoundError):
+            run_command(["definitely-not-a-real-binary-xyz-12345"])
+
+        # Then
+        messages = [r.getMessage() for r in sh_caplog.records if r.name == "nclutils.sh"]
+        assert any("definitely-not-a-real-binary-xyz-12345" in m for m in messages)
+
+
 class TestRunCommandStreaming:
     """Tests for stream=True and exclude_regex."""
 


### PR DESCRIPTION
## Summary

- Add a `nclutils.sh` DEBUG logger that emits the shlex-joined final argv on every `run_command` call, gated by `logger.isEnabledFor(logging.DEBUG)` so the formatting cost is skipped when no handler is attached.
- Remove the now-redundant `nclutils.git` logger and its `logger.debug(" ".join(argv))` in `run_git` — every git invocation already surfaces through the sh logger.
- Document the behavior in `docs/shell_commands.md` (new "Diagnostic logging" section) and update `docs/git.md` to point readers at the sh logger.
- Add a shared `sh_caplog` fixture in `tests/conftest.py` (mirrors the existing `fs_caplog`) so test sites don't open-code `caplog.set_level(...)`.

## Test plan

- [x] `uv run pytest` (554 passed)
- [x] `uv run ruff check` / `uv run ruff format` on all changed files
- [x] `uv run ty check` on changed source files
- [x] New `TestRunCommandLogging` covers: argv at DEBUG (parametrized over plain + space-containing args, asserting shlex quoting), and logging-before-spawn for missing executables
- [x] `tests/git/test_runner.py::test_logs_at_debug_level` updated to assert the invocation surfaces under `nclutils.sh` AND that no records are emitted under the retired `nclutils.git` logger (regression guard)