### PR TITLE
refactor(pp)!: rework step() outcome control for manual fail/skip

### DIFF
--- a/docs/pp.md
+++ b/docs/pp.md
@@ -265,7 +265,7 @@ with pp.step("running migrations") as s:
 
 On exit the spinner stops, the marker (`✓` or `✗`) is rendered, and any sub-items remain on screen so the final output is a static record of what happened.
 
-For transient progress that shouldn't clutter the final transcript, pass `ephemeral=True`. The spinner and sub-items are wiped on success, leaving no trace on the console. If the block calls `s.fail()`, a fresh error line still surfaces on stderr after the wipe (see [Failing a step](#failing-a-step)):
+For transient progress that shouldn't clutter the final transcript, pass `ephemeral=True`. The spinner and sub-items are wiped on success, leaving no trace on the console. If the block calls `s.fail()`, a fresh error line still surfaces on stderr after the wipe:
 
 ```python
 with pp.step("warming caches", ephemeral=True) as s:
@@ -353,6 +353,13 @@ with pp.step("warming caches") as s:
 ```
 
 Code after `s.skip(...)` does not run. Skip is not an error; in ephemeral mode it wipes the spinner with no extra console output.
+
+```python
+with pp.step("warming caches", ephemeral=True) as s:
+    if cache.is_warm():
+        s.skip("caches already warm")
+# wipes with no console output
+```
 
 ## File logging
 

--- a/docs/pp.md
+++ b/docs/pp.md
@@ -1,6 +1,6 @@
 # Pretty Printing
 
-Themed console output and file logging for Python CLI scripts. A thin layer over [Rich](https://github.com/Textualize/rich) that gives you `info` / `success` / `warning` / `error` / `debug` / `trace` / `dryrun` calls, a spinner-driven `step()` context manager, and an optional parallel logfile.
+Themed console output and a parallel logfile for Python CLI scripts. A thin layer over [Rich](https://github.com/Textualize/rich) that gives you `info` / `success` / `warning` / `error` / `debug` / `trace` / `dryrun` calls, a spinner-driven `step()` context manager, automatic stdout/stderr routing, and per-level markers.
 
 ```python
 from nclutils import pp
@@ -15,9 +15,7 @@ pp.warning("API rate limit at 80%")
 ! API rate limit at 80%
 ```
 
-## What it owns
-
-`pp` handles the four things that grow out of `print()` in any non-trivial CLI script: the verbosity gates (`--verbose` / `--quiet`), the stdout/stderr split, Rich-markup escaping for untrusted input, and a preset theme.
+`pp` handles the four things that grow out of `print()` in any non-trivial CLI script: `--verbose` / `--quiet` gating, stdout/stderr routing, Rich-markup escaping for untrusted input, and a consistent theme.
 
 ## Quick start
 
@@ -25,33 +23,86 @@ pp.warning("API rate limit at 80%")
 import time
 from nclutils import pp
 
-pp.configure(verbosity=pp.Verbosity.DEBUG)
-
 pp.info("starting build")
 
 with pp.step("compiling sources") as s:
     time.sleep(0.5)
-    s.sub("compiling src/api.py")
-    s.sub("compiling src/cli.py")
+    s.sub("src/api.py")
+    s.sub("src/cli.py")
 
 pp.success("build complete", details=["artifact: dist/app-1.4.2.tar.gz"])
 ```
 
-The `pp.step()` block shows a live spinner with sub-items beneath it. On success it turns into a green checkmark; on any exception (including `SystemExit` and `KeyboardInterrupt`) it turns into a red X and the exception re-raises.
+`pp.step()` shows a live spinner while the body runs. On natural completion it resolves to a green checkmark, and the sub-items remain on screen. `pp.success(..., details=[...])` renders the details as a small tree beneath the message.
 
 ## Output levels
 
-Every level routes through the same shape: `pp.func(message, details=[...])`. `details` is optional. Items render as a tree beneath the message. Non-final items are prefixed with `├─` and the final item with `└─`, matching `pp.step()`'s sub-item layout. Multi-line renderables (Tables, JSON, multi-line `Pretty` outputs) get a `│ ` continuation pipe under non-final positions and a blank gutter under the final position. String items are colored with the level's `detail_style`; Rich markup is escaped by default so user-supplied strings can't inject styling. Non-strings are auto-rendered with Rich (dicts, dataclasses, and arbitrary objects via `Pretty`; `JSON` / `Syntax` / `Table` pass through unchanged).
-
-For example, this call:
+Every level method routes through the same shape:
 
 ```python
-from nclutils import pp
-
-pp.success("deployed", details=["build #1742", "rollout 100%", "duration: 3.2s"])
+pp.func(message, *, details=None, markup=False, tag=None, right_tag=None, exception=False)
 ```
 
-renders as:
+| Function      | Stream | Marker                       | Gated by                   |
+| ------------- | ------ | ---------------------------- | -------------------------- |
+| `pp.info`     | stdout | (none)                       | `quiet` suppresses         |
+| `pp.success`  | stdout | `✓`                          | `quiet` suppresses         |
+| `pp.warning`  | stderr | `!`                          | always renders             |
+| `pp.error`    | stderr | `✗`                          | always renders             |
+| `pp.critical` | stderr | `‼`                          | always renders             |
+| `pp.dryrun`   | stdout | `~ [dry-run]`                | always renders             |
+| `pp.debug`    | stdout | `›`                          | shown at `DEBUG` or higher |
+| `pp.trace`    | stdout | `·`                          | shown at `TRACE`           |
+| `pp.header`   | stdout | (rule line)                  | `quiet` suppresses         |
+| `pp.step`     | stdout | spinner, then outcome marker | always renders             |
+
+`pp.critical` is severity-only and does not raise. Use it for "the world is broken" notices that warrant more visual weight than `pp.error`.
+
+`pp.header()` draws a `Console.rule()` with an optional centered title to break long output into scannable sections:
+
+```python
+pp.header("phase 1: download")
+# ... work ...
+pp.header("phase 2: process")
+```
+
+### Wiring up `--verbose` and `--quiet`
+
+`pp.Verbosity` is an `IntEnum` with `INFO`, `DEBUG`, `TRACE`, so a `-v` count flag maps cleanly:
+
+```python
+import argparse
+from nclutils import pp
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-v", "--verbose", action="count", default=0)
+parser.add_argument("-q", "--quiet", action="store_true")
+args = parser.parse_args()
+
+pp.configure(verbosity=args.verbose, quiet=args.quiet)
+```
+
+The two flags are independent:
+
+- `verbosity` only gates `debug` and `trace`. The default is `INFO`. Out-of-range integers are clamped, so `-vvvvv` is safe.
+- `quiet=True` suppresses `info`, `success`, `header`, and `kv`. Warnings, errors, dry-run notices, and step lifecycle still render.
+
+Combining `--verbose --quiet` is reasonable: debug output without the routine info chatter.
+
+`pp.configure()` is a partial update. Fields you don't pass are left alone, so you can call it as many times as you like:
+
+```python
+pp.configure(verbosity=pp.Verbosity.DEBUG)
+pp.configure(quiet=True)   # verbosity still DEBUG
+```
+
+## Detail trees
+
+Pass `details=[...]` to render items as a tree beneath the message. Non-final items are prefixed with `├─`, the final item with `└─`:
+
+```python
+pp.success("deployed", details=["build #1742", "rollout 100%", "duration: 3.2s"])
+```
 
 ```text
 ✓ deployed
@@ -60,50 +111,42 @@ renders as:
   └─ duration: 3.2s
 ```
 
-The `├─` and `└─` glyphs are styled via the `sub.pipe` theme key (the same key `pp.step()` uses for its sub-item connectors), so retuning that one entry restyles every tree connector across the API.
+String items are escaped by default and colored with the level's `detail_style`. Multi-line renderables (Tables, JSON, multi-line `Pretty` outputs) get a `│ ` continuation pipe under non-final positions and a blank gutter under the final position. Non-strings auto-render with Rich: dicts, dataclasses, and arbitrary objects go through `Pretty`; `JSON` / `Syntax` / `Table` pass through unchanged.
+
+```python
+from rich.json import JSON
+
+pp.debug("got response", details=[response_dict])
+pp.debug("raw payload", details=[JSON(resp.text)])
+```
+
+The connector glyphs share the `sub.pipe` Rich theme key (the same one `pp.step()` uses for its sub-items), so retuning that one entry restyles every tree connector across the API.
 
 > [!NOTE]
-> Tree connectors appear in stdout/stderr only. In logfile records, each detail item becomes its own log record at the parent's severity with the detail text in the standard `%(message)s` field, prefixed by two spaces; the file does not contain `├─`, `└─`, or `│` characters.
+> Tree connectors appear in stdout/stderr only. In logfile records, each detail item becomes its own log record at the parent's severity with the detail text in the standard `%(message)s` field, prefixed by two spaces. The file does not contain `├─`, `└─`, or `│` characters.
 
-Pass `markup=True` to opt into Rich markup parsing for `message` and any string `details` items in that call:
+## Markup and escaping
+
+Strings passed to any level method are Rich-markup-escaped by default. `[red]` in a message renders literally, not as styling. Pass `markup=True` to opt into parsing:
 
 ```python
 from rich.text import Text
 from nclutils import pp
 
 pp.info("Found [bold]42[/] matches", markup=True)
-pp.info(Text.from_markup("Found [bold]42[/] matches"))  # Text instances always keep their styling
+pp.info(Text.from_markup("Found [bold]42[/] matches"))   # Text instances always keep their styling
 ```
 
-Use `markup=True` when _you_ control the string. When the message comes from arbitrary input (file paths, exception messages, JSON snippets), keep the default escape so brackets in the input can't accidentally render as styling or raise `MarkupError`.
+Use `markup=True` only when you control the string. For arbitrary input (file paths, exception messages, JSON snippets), keep the default escape so brackets can't accidentally render as styling or raise `MarkupError`.
 
-| Function      | Stream | Marker                   | Gated by                   |
-| ------------- | ------ | ------------------------ | -------------------------- |
-| `pp.info`     | stdout | (none)                   | `quiet` suppresses         |
-| `pp.success`  | stdout | `✓`                      | `quiet` suppresses         |
-| `pp.warning`  | stderr | `!`                      | always renders             |
-| `pp.error`    | stderr | `✗`                      | always renders             |
-| `pp.critical` | stderr | `‼`                      | always renders             |
-| `pp.dryrun`   | stdout | `~ [dry-run]`            | always renders             |
-| `pp.debug`    | stdout | `›`                      | shown at `DEBUG` or higher |
-| `pp.trace`    | stdout | `·`                      | shown at `TRACE`           |
-| `pp.header`   | stdout | (rule line)              | `quiet` suppresses         |
-| `pp.step`     | stdout | spinner, then `✓` or `✗` | always renders             |
+## Per-call tags
 
-`pp.critical` is severity-only and does not raise. Use it for "the world is broken" notices that warrant a more emphatic visual than `pp.error`.
-
-Every level method (`info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`) accepts the optional `tag=` and `right_tag=` kwargs documented in [Per-call tags](#per-call-tags) below.
-
-### Per-call tags
-
-Every level method accepts `tag=` and `right_tag=` for one-off metadata that doesn't warrant a theme change:
+Every level method accepts `tag=` and `right_tag=` for one-off metadata:
 
 ```python
 pp.info("saved", tag="api", right_tag="200ms")
 pp.error("upload failed", tag="uploader")
 ```
-
-Renders:
 
 ```text
 [api] saved                                                            200ms
@@ -112,16 +155,16 @@ Renders:
 
 `tag` is dim text rendered between the marker and the message. It is recorded inline in the logfile (`[api] saved`) so file consumers see the same metadata that appeared on the console.
 
-`right_tag` is dim text right-aligned to the console width on the first line only. It is **presentation-only** and is never written to the logfile.
+`right_tag` is dim text right-aligned to the console width on the first line only. It is presentation-only and is never written to the logfile.
 
-When `right_tag` is passed to `pp.debug` or `pp.trace`, the caller's value replaces the auto-elapsed `[+s.fffs]` marker on the console; the logfile still records the elapsed timing so the audit trail is preserved.
+When `right_tag` is passed to `pp.debug` or `pp.trace`, the caller's value replaces the auto-elapsed `[+s.fffs]` marker on the console. The logfile still records the elapsed timing so the audit trail is preserved.
 
 `pp.dryrun` combines a caller-supplied `tag` with its built-in `[dry-run]` marker on both the console and the logfile, with the caller's tag rendered first (`[deploy] [dry-run] would push`).
 
 > [!NOTE]
 > The caller is responsible for Rich-markup-escaping any `[`, `]`, or other reserved characters in `tag` and `right_tag`. Pass plain ASCII tags or pre-escaped strings.
 
-### Exceptions and tracebacks
+## Tracebacks
 
 Every level method accepts an `exception=` kwarg. Pass an exception instance to render a styled Rich Traceback below the message:
 
@@ -152,36 +195,14 @@ except UploadError:
 
 Outside an `except` block, `exception=True` is a silent no-op (matches the behavior of `logging.exception()`).
 
-Pass `show_locals=True` for verbose dumps that include each frame's local variables. Rich handles its own glyph fallbacks based on console encoding, so the traceback renders cleanly on terminals that can't display box-drawing characters.
-
-The formatted traceback is also written to the logfile as continuation lines under the parent record at the same severity, so a level filter drops the traceback alongside its message.
+Pass `show_locals=True` for verbose dumps that include each frame's local variables. The formatted traceback is also written to the logfile as continuation lines under the parent record at the same severity, so a level filter drops the traceback alongside its message.
 
 > [!NOTE]
-> `exception=` is accepted on every level method (`info`, `success`, `warning`, `error`, `critical`, `debug`, `trace`, `dryrun`). It is not supported on `header()` or `step()`, both of which already manage their own exception display.
-
-You can pass Rich renderables in `details` to get syntax-aware output, which is especially useful at `debug` / `trace`:
-
-```python
-from rich.json import JSON
-from nclutils import pp
-
-pp.debug("got response", details=[response_dict])
-pp.debug("raw payload", details=[JSON(resp.text)])
-```
-
-`pp.header()` draws a `Console.rule()` with an optional centered title to break long output into scannable sections:
-
-```python
-from nclutils import pp
-
-pp.header("phase 1: download")
-# ... work ...
-pp.header("phase 2: process")
-```
+> `exception=` is accepted on every level method (`info`, `success`, `warning`, `error`, `critical`, `debug`, `trace`, `dryrun`). It is not supported on `header()` or `step()`, both of which manage their own outcome display. For `step()`, use `s.fail(message, exception=...)` instead.
 
 ## Key/value blocks
 
-`pp.kv()` renders aligned key/value pairs as a clean section block, which is handy for status summaries and final-state output:
+`pp.kv()` renders aligned key/value pairs as a clean section block, useful for status summaries and final-state output:
 
 ```python
 pp.header("Build Status")
@@ -202,7 +223,7 @@ pp.kv({
   Duration: 3.2s
 ```
 
-Keys are padded automatically, so you don't need to pre-align them. Pass a `list[tuple[str, Any]]` when you need duplicate keys or want to control ordering explicitly:
+Keys are padded automatically. Pass a `list[tuple[str, Any]]` when you need duplicate keys or want explicit ordering:
 
 ```python
 pp.kv([
@@ -212,47 +233,14 @@ pp.kv([
 ])
 ```
 
-The default `indent=2` and `separator=": "` work for typical CLI output. Pass `markup=True` to parse Rich markup in string values; keys are always escaped (treated as identifiers).
+`indent=2` and `separator=": "` are the defaults. Pass `markup=True` to parse Rich markup in string values. Keys are always escaped (treated as identifiers). Non-string, non-renderable values pass through `str()`. Rich renderables (Tables, JSON, etc.) render below the key, indented to the value column.
 
 > [!NOTE]
 > `pp.kv()` is suppressed on the console by `quiet=True`, the same as `pp.info()` and `pp.success()`. Each pair is still recorded as one INFO record in the logfile (or one record per visual line for multi-line values), so the audit trail stays complete even under quiet.
 
-Non-string, non-renderable values pass through `str()`. Rich renderables (Tables, JSON, etc.) render below the key, indented to the value column.
-
-## Wiring up `--verbose` and `--quiet`
-
-`pp.Verbosity` is an `IntEnum` with three levels (`INFO`, `DEBUG`, `TRACE`), so a `-v` count flag maps cleanly:
-
-```python
-import argparse
-from nclutils import pp
-
-parser = argparse.ArgumentParser()
-parser.add_argument("-v", "--verbose", action="count", default=0)
-parser.add_argument("-q", "--quiet", action="store_true")
-args = parser.parse_args()
-
-pp.configure(verbosity=args.verbose, quiet=args.quiet)
-```
-
-Out-of-range integers are clamped, so `-vvvvv` is safe.
-
-The two flags are independent gates:
-
-- `verbosity` only gates `debug` and `trace`. The default is `INFO`.
-- `quiet=True` suppresses `info`, `success`, and `header`. Warnings, errors, dry-run notices, and steps still render.
-- `--verbose --quiet` is a sensible combination: you get debug output without the routine info chatter.
-
-`pp.configure()` is a partial update. Fields you don't pass are left alone. Call it as many times as you like:
-
-```python
-pp.configure(verbosity=pp.Verbosity.DEBUG)
-pp.configure(quiet=True)         # verbosity still DEBUG
-```
-
 ## The `step()` context manager
 
-`pp.step()` renders a Rich `Live` spinner that updates while your code runs, then resolves to a success or failure marker:
+`pp.step()` renders a Rich `Live` spinner while the body runs, then resolves to one of four outcomes:
 
 ```python
 from nclutils import pp
@@ -263,9 +251,16 @@ with pp.step("running migrations") as s:
         s.sub(f"applied {migration.name}")
 ```
 
-On exit the spinner stops, the marker (`✓` or `✗`) is rendered, and any sub-items remain on screen so the final output is a static record of what happened.
+| Trigger                                  | Outcome                                                                                                                          |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Block exits naturally                    | Green `✓` marker. The success line keeps the original `message` (or whatever `success_msg=` / `s.set_success_msg()` set).        |
+| `s.fail(msg)` called inside the block    | Red `✗` marker, `failed:` logfile entry. The block exits early; code after `s.fail()` does not run.                              |
+| `s.skip(msg)` called inside the block    | Info-styled completion (no checkmark, no error glyph), `skipped:` logfile entry. The block exits early.                          |
+| Any other exception escapes the block    | Exception propagates to the caller. No marker, no log line. The spinner is replaced with a static line so it doesn't stay frozen on screen; sub-items remain. The caller owns error reporting. |
 
-For transient progress that shouldn't clutter the final transcript, pass `ephemeral=True`. The spinner and sub-items are wiped on success, leaving no trace on the console. If the block calls `s.fail()`, a fresh error line still surfaces on stderr after the wipe:
+Sub-items added via `s.sub()` render beneath the spinner during the step and remain on screen beneath the final completion line.
+
+For transient progress that shouldn't clutter the final transcript, pass `ephemeral=True`. The spinner and sub-items are wiped on natural completion or `s.skip()`, leaving no console trace. `s.fail()` still surfaces a fresh `✗ message` line on stderr after wiping, so failures aren't silently hidden.
 
 ```python
 with pp.step("warming caches", ephemeral=True) as s:
@@ -290,9 +285,9 @@ with pp.step(
     s.sub("cli.py")
 ```
 
-On success the spinner resolves to `✓ compiled 42 files in 1.2s`. The override message is also recorded in the `succeeded:` logfile line so the audit trail matches what the user saw.
+The success line resolves to `✓ compiled 42 files in 1.2s`. The override is also recorded in the `succeeded:` logfile entry.
 
-When the success text depends on work done inside the block (a count, a duration, an output path), call `s.set_success_msg()` from inside the block:
+When the success text depends on work done inside the block (a count, a duration, an output path), call `s.set_success_msg()`:
 
 ```python
 with pp.step("compiling sources") as s:
@@ -304,22 +299,22 @@ with pp.step("compiling sources") as s:
     s.set_success_msg(f"compiled {len(processed)} files")
 ```
 
-The setter wins over the `success_msg` kwarg, which wins over the original message. Each takes its own `markup=` flag.
+The setter wins over the `success_msg` kwarg, which wins over the original message. Each takes its own `markup=` flag. `s.set_success_msg()` does not exit the block; it just records the message for natural completion.
 
 ### Failing a step
 
-When the work didn't succeed, call `s.fail(message)` from inside the block. This exits the `with` block immediately, replaces the spinner with an error marker, and writes a `failed:` line to the logfile:
+Call `s.fail(message)` inside the block to render the failure marker and exit early. Code after the call doesn't run:
 
 ```python
 with pp.step("compiling sources") as s:
     for path in sources:
         if not path.exists():
-            s.fail(f"missing source: {path}")  # exits here
+            s.fail(f"missing source: {path}")   # exits here
         compile_one(path)
     s.set_success_msg(f"compiled {len(sources)} files")
 ```
 
-Code after `s.fail(...)` inside the block does not run. To attach an exception's type and message to the `failed:` log line, pass `exception=`:
+To attach an exception's type and message to the `failed:` log line, pass `exception=`:
 
 ```python
 with pp.step("compiling sources") as s:
@@ -332,27 +327,18 @@ with pp.step("compiling sources") as s:
 > [!NOTE]
 > `s.fail()` is the only way to render the failure marker. An uncaught exception inside `step()` propagates through cleanly with no marker and no log line, leaving the original message visible (no spinner) and any sub-items intact. The caller owns error reporting in that path.
 
-When `ephemeral=True`, `s.fail()` still surfaces a fresh error line on stderr after wiping the spinner, so failures are never silently hidden:
-
-```python
-with pp.step("warming caches", ephemeral=True) as s:
-    if not cache_target_reachable():
-        s.fail("cache target unreachable")
-# stderr shows: ✗ cache target unreachable
-```
-
 ### Skipping a step
 
-When the work the step describes did not run (nothing to do, preconditions unmet, intentional bypass), call `s.skip(message)`. This exits the `with` block immediately, replaces the spinner with an info-styled completion (no checkmark, no error glyph), and writes a `skipped:` line to the logfile:
+Call `s.skip(message)` when the work didn't run (nothing to do, preconditions unmet, intentional bypass). Skip is not an error: the completion renders with info-level styling (no checkmark, no error glyph) and the logfile records a `skipped:` line:
 
 ```python
 with pp.step("warming caches") as s:
     if cache.is_warm():
-        s.skip("caches already warm")  # exits here
+        s.skip("caches already warm")   # exits here
     warm_cache()
 ```
 
-Code after `s.skip(...)` does not run. Skip is not an error; in ephemeral mode it wipes the spinner with no extra console output.
+In ephemeral mode, skip wipes the spinner with no extra output:
 
 ```python
 with pp.step("warming caches", ephemeral=True) as s:
@@ -391,30 +377,30 @@ Produces `run.log`:
 2026-05-04 14:32:01.236 | INFO     | succeeded: compile assets
 ```
 
-Console rendering and file rendering are independent. The console ignores `loglevel`; the file ignores `quiet` and `verbosity`. Every level method writes to the file before checking its console gate, so the logfile remains a complete audit trail.
+Console and file rendering are independent. The console ignores `loglevel`; the file ignores `quiet` and `verbosity`. Every level method writes to the file before checking its console gate, so the logfile is a complete audit trail.
 
 ### What gets logged
 
-| Emission                      | Logged at                         | Notes                                                                                                  |
-| ----------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `info` / `success` / `dryrun` | `INFO` (20)                       | `success`/`dryrun` aren't real severities. `dryrun` keeps `[dry-run]` inline.                          |
-| `debug`                       | `DEBUG` (10)                      | `[+s.fffs]` elapsed tag inlined into message.                                                          |
-| `trace`                       | `TRACE` (5)                       | Custom level registered with stdlib `logging` at import.                                               |
-| `warning`                     | `WARNING` (30)                    |                                                                                                        |
-| `error`                       | `ERROR` (40)                      |                                                                                                        |
-| `critical`                    | `CRITICAL` (50)                   | Severity-only and does not raise.                                                                      |
-| `step()` lifecycle            | `INFO` start, `INFO`/`ERROR` exit | `ephemeral=True` does not suppress file output.                                                        |
-| `Step.sub()`                  | `INFO`                            | Indented continuation, written immediately.                                                            |
-| `kv()`                        | `INFO` (20)                       | One INFO record per pair; one per visual line for multi-line values. Recorded even under `quiet=True`. |
-| `header()`                    | (not logged)                      | Console-only structural sugar.                                                                         |
+| Emission                      | Logged at                     | Notes                                                                                                  |
+| ----------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `info` / `success` / `dryrun` | `INFO` (20)                   | `success`/`dryrun` aren't real severities. `dryrun` keeps `[dry-run]` inline.                          |
+| `debug`                       | `DEBUG` (10)                  | `[+s.fffs]` elapsed tag inlined into message.                                                          |
+| `trace`                       | `TRACE` (5)                   | Custom level registered with stdlib `logging` at import.                                               |
+| `warning`                     | `WARNING` (30)                |                                                                                                        |
+| `error`                       | `ERROR` (40)                  |                                                                                                        |
+| `critical`                    | `CRITICAL` (50)               | Severity-only and does not raise.                                                                      |
+| `step()` lifecycle            | `INFO` start, outcome at exit | `succeeded:` / `failed:` / `skipped:` line at exit. Uncaught exceptions write only the `starting:` line. |
+| `Step.sub()`                  | `INFO`                        | Indented continuation, written immediately.                                                            |
+| `kv()`                        | `INFO` (20)                   | One INFO record per pair; one per visual line for multi-line values. Recorded even under `quiet=True`. |
+| `header()`                    | (not logged)                  | Console-only structural sugar.                                                                         |
 
-Filtering with `loglevel=pp.LogLevel.WARNING` drops every `info` / `success` / `dryrun` / `debug` / `trace` emission and its detail continuations as a unit. `LogLevel` is severity-shaped, not emission-shaped, so there's no way to "log only successes."
+Filtering with `loglevel=pp.LogLevel.WARNING` drops every `info` / `success` / `dryrun` / `debug` / `trace` emission and its detail continuations together. `LogLevel` filters by severity, not by emission type, so there's no way to "log only successes."
 
 ### What's not included
 
-The logfile is for CLI audit and diagnostic capture. It does not ship rotation, JSON output, syslog, or multi-process safety. If you need those, run `pp` on top of your own preconfigured `logging.Logger`, or use external rotation (`logrotate`, `savelog`).
+The logfile is for CLI audit and diagnostic capture. It doesn't ship rotation, JSON output, syslog, or multi-process safety. If you need those, run `pp` on top of your own preconfigured `logging.Logger`, or use external rotation (`logrotate`, `savelog`).
 
-## Customizing the theme
+## Theming
 
 The seven output levels (`info`, `success`, `warning`, `error`, `debug`, `trace`, `dryrun`) each expose three things you can override: the main message style, the indented detail style, and the marker glyph. Override any combination in a `Theme`:
 
@@ -424,7 +410,7 @@ from nclutils import pp
 pp.configure(
     theme=pp.Theme(
         success=pp.Level(style="cyan", marker="🎉 "),
-        warning=pp.Level(marker=""),  # hide the warning marker entirely
+        warning=pp.Level(marker=""),   # hide the warning marker entirely
     ),
 )
 
@@ -436,8 +422,6 @@ Anything you don't set keeps its default. `pp.Level(style="cyan")` only changes 
 Successive `pp.configure(theme=...)` calls accumulate at the field level:
 
 ```python
-from nclutils import pp
-
 pp.configure(theme=pp.Theme(success=pp.Level(style="blue", marker="🎉 ")))
 pp.configure(theme=pp.Theme(success=pp.Level(detail_style="navy")))
 # success now has style="blue", detail_style="navy", marker="🎉 "
@@ -451,44 +435,29 @@ The horizontal rule under `pp.header()` and the `[dry-run]` tag are not customiz
 
 ### ASCII fallback
 
-When the console's encoding can't produce the default unicode glyphs (e.g. `LANG=C`, `PYTHONIOENCODING=ascii`, or a Windows host whose code page rejects box-drawing characters), `pp` automatically falls back to an ASCII-only rendering. Detection is automatic, there is no flag to set:
+When the console's encoding can't produce the default unicode glyphs (`LANG=C`, `PYTHONIOENCODING=ascii`, or a Windows host whose code page rejects box-drawing characters), `pp` falls back to ASCII automatically. Detection is automatic; there is no flag to set.
 
 - Detail tree connectors (`├─`, `└─`, `│`) collapse to a simple `- ` prefix on every line, with continuation lines aligned under the value column.
 - `pp.step()` sub-items render with the same `- ` prefix instead of tree connectors.
 - Default level markers fall back per the table below.
 
-| Level    | Unicode | ASCII    |
-| -------- | ------- | -------- |
-| info     | (none)  | (none)   |
-| success  | `✓`     | `+`      |
-| warning  | `!`     | `!`      |
-| error    | `✗`     | `x`      |
-| critical | `‼`     | `!!`     |
-| debug    | `›`     | `>`      |
-| trace    | `·`     | `.`      |
-| dryrun   | `~`     | `~`      |
+| Level    | Unicode | ASCII |
+| -------- | ------- | ----- |
+| info     | (none)  | (none)|
+| success  | `✓`     | `+`   |
+| warning  | `!`     | `!`   |
+| error    | `✗`     | `x`   |
+| critical | `‼`     | `!!`  |
+| debug    | `›`     | `>`   |
+| trace    | `·`     | `.`   |
+| dryrun   | `~`     | `~`   |
 
 User-supplied `pp.Theme(level=pp.Level(marker=...))` markers are always respected verbatim, even on ASCII consoles. The fallback only triggers when a level still has its built-in default marker.
 
 > [!NOTE]
 > Detection probes `console.encoding` at render time and chooses the rendering path per call. To force one path or the other, build your own `Console` with the desired encoding and pass it via `pp.configure(console=...)` or `pp.Emitter(console=...)`.
 
-## Reaching the underlying consoles
-
-When you need to render a Rich object (`Table`, `Syntax`, `Panel`, …) on the same stream the level functions write to, use the `pp.console()` and `pp.err_console()` accessors:
-
-```python
-from rich.table import Table
-from nclutils import pp
-
-table = Table("name", "status")
-table.add_row("api", "ok")
-pp.console().print(table)
-
-pp.err_console().print("[bold red]fatal[/]")
-```
-
-## Library use: isolated emitters
+## Library use and testing
 
 The module-level functions delegate to a shared default `Emitter`. If you're writing a library that needs its own output configuration without trampling its host CLI's settings, instantiate an `Emitter` directly:
 
@@ -501,6 +470,19 @@ logger.debug("only this emitter's verbosity matters here")
 ```
 
 Each `Emitter` owns its own `verbosity`, `quiet`, `console`, `err_console`, and logfile. Nothing leaks across instances.
+
+When you need to render a Rich object (`Table`, `Syntax`, `Panel`, etc.) on the same stream the level functions write to, use `pp.console()` and `pp.err_console()`:
+
+```python
+from rich.table import Table
+from nclutils import pp
+
+table = Table("name", "status")
+table.add_row("api", "ok")
+pp.console().print(table)
+
+pp.err_console().print("[bold red]fatal[/]")
+```
 
 For tests, swap in a recording console so you can assert on output:
 
@@ -536,14 +518,59 @@ finally:
 
 Every name below is available on the `pp` namespace (`from nclutils import pp`) and from `nclutils.pp` directly (e.g. `from nclutils.pp import info`).
 
-- `info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`, `header`. Output functions. Every level function accepts `tag=` / `right_tag=` (see [Per-call tags](#per-call-tags)) and `exception=` / `show_locals=` (see [Exceptions and tracebacks](#exceptions-and-tracebacks)).
-- `kv(items, *, indent=2, separator=": ", markup=False)`. Render aligned key/value blocks (see [Key/value blocks](#keyvalue-blocks)).
-- `step(message, *, ephemeral=False)`. Spinner context manager.
-- `configure(*, verbosity=None, quiet=None, console=None, err_console=None, theme=None, logfile=None, loglevel=None, logfmt=None)`. Partial update of the default emitter.
-- `Emitter`. Instantiate directly for isolated configuration.
-- `Theme`, `Level`. Per-level style and marker overrides. Pass `Theme(success=Level(...))` to `configure()` or `Emitter()`.
-- `Verbosity`. `IntEnum` with `INFO`, `DEBUG`, `TRACE`.
-- `LogLevel`. `IntEnum` aligned with stdlib `logging` (`TRACE=5`, `DEBUG=10`, …, `CRITICAL=50`). Used as the `loglevel=` filter cutoff for the logfile.
-- `THEME`. The Rich `Theme` used by default consoles, in case you build your own.
-- `console()`, `err_console()`. Return the default emitter's stdout / stderr `Console` for direct Rich rendering. Re-resolves on each call.
-- `get_default()`, `set_default(emitter)`. Read or replace the shared default emitter.
+### Output functions
+
+`info`, `success`, `warning`, `error`, `critical`, `dryrun`, `debug`, `trace`. Every level method accepts:
+
+- `message`: the body text. Strings are escaped unless `markup=True`. Rich renderables pass through unchanged.
+- `details=None`: optional iterable rendered as a tree beneath the message.
+- `markup=False`: parse Rich markup in `message` and string `details` items.
+- `tag=None` / `right_tag=None`: see [Per-call tags](#per-call-tags).
+- `exception=False` / `show_locals=False`: see [Tracebacks](#tracebacks).
+- `style=None` / `detail_style=None` / `marker=None`: per-call overrides of the level's theme.
+
+### Structural output
+
+```python
+header(message="", *, align="center", markup=False, **kwargs) -> None    # **kwargs forwarded to Console.rule()
+kv(items, *, indent=2, separator=": ", markup=False) -> None
+```
+
+### `step()` context manager
+
+```python
+step(message, *, ephemeral=False, markup=False, success_msg=None) -> Generator[Step]
+```
+
+The yielded `Step` object has four public methods:
+
+```python
+Step.sub(text, *, markup=False) -> None
+Step.set_success_msg(message, *, markup=False) -> None
+Step.fail(message, *, exception=False, markup=False) -> NoReturn
+Step.skip(message, *, markup=False) -> NoReturn
+```
+
+- `s.sub()`: append a sub-item beneath the spinner. Persists beneath the completion line in non-ephemeral mode.
+- `s.set_success_msg()`: override the success header. Does NOT exit the block; applied at natural completion. Ignored if the block exits via `fail()`, `skip()`, or an uncaught exception.
+- `s.fail()`: exit the block with a failure outcome (renders `✗`, writes `failed:` to the logfile). Pass `exception=` to attach exception details. Code after the call doesn't run.
+- `s.skip()`: exit the block with a skip outcome (info-styled completion, `skipped:` log line). Code after the call doesn't run.
+
+### Configuration
+
+```python
+configure(*, verbosity=None, quiet=None, console=None, err_console=None,
+          theme=None, logfile=None, loglevel=None, logfmt=None) -> None
+```
+
+Partial update of the shared default emitter. Fields you don't pass are left alone.
+
+### Emitter and supporting types
+
+- `Emitter(*, verbosity=Verbosity.INFO, quiet=False, console=None, err_console=None, theme=None, logfile=None, loglevel=LogLevel.INFO, logfmt=None)`: instantiate directly for isolated configuration. Same kwargs as `configure()`, but with positive defaults instead of `None`.
+- `Theme`, `Level`: per-level style and marker overrides. Pass `Theme(success=Level(...))` to `configure()` or `Emitter()`.
+- `Verbosity`: `IntEnum` with `INFO`, `DEBUG`, `TRACE`.
+- `LogLevel`: `IntEnum` aligned with stdlib `logging` (`TRACE=5`, `DEBUG=10`, …, `CRITICAL=50`). Used as the `loglevel=` filter cutoff for the logfile.
+- `THEME`: the Rich `Theme` used by default consoles, in case you build your own.
+- `console()`, `err_console()`: return the default emitter's stdout / stderr `Console` for direct Rich rendering. Re-resolves on each call.
+- `get_default()`, `set_default(emitter)`: read or replace the shared default emitter.

--- a/docs/pp.md
+++ b/docs/pp.md
@@ -265,85 +265,94 @@ with pp.step("running migrations") as s:
 
 On exit the spinner stops, the marker (`✓` or `✗`) is rendered, and any sub-items remain on screen so the final output is a static record of what happened.
 
-For transient progress that shouldn't clutter the final transcript, pass `ephemeral=True`. The spinner and sub-items are wiped on success; on failure only the red X surfaces:
+For transient progress that shouldn't clutter the final transcript, pass `ephemeral=True`. The spinner and sub-items are wiped on success, leaving no trace on the console. If the block calls `s.fail()`, a fresh error line still surfaces on stderr after the wipe (see [Failing a step](#failing-a-step)):
 
 ```python
 with pp.step("warming caches", ephemeral=True) as s:
     warm_cache()
     s.sub("cache populated")
-# success leaves no trace; failure still prints "✗ warming caches"
+# success leaves no trace
 ```
 
 > [!WARNING]
 > `pp.step()` cannot nest. Rich's `Live` doesn't stack, so nesting silently corrupts the parent's display. `pp` raises `RuntimeError` when you try.
 
-### Customizing the success and failure messages
+### Customizing the success message
 
-By default `step()` reuses the original message for both success and failure. To show different text on completion, pass `success_msg` and/or `failure_msg`:
+By default `step()` reuses the original message on success. To show different text, pass `success_msg`:
 
 ```python
 with pp.step(
     "compiling sources",
     success_msg="compiled 42 files in 1.2s",
-    failure_msg="compilation aborted",
 ) as s:
     s.sub("api.py")
     s.sub("cli.py")
 ```
 
-On success the spinner resolves to `✓ compiled 42 files in 1.2s`; on failure to `✗ compilation aborted`. Either kwarg can be omitted independently, and the omitted side falls back to the original message. The single `markup=` flag covers all three messages.
+On success the spinner resolves to `✓ compiled 42 files in 1.2s`. The override message is also recorded in the `succeeded:` logfile line so the audit trail matches what the user saw.
 
-The override messages are also recorded in the logfile (`succeeded: ...` / `failed: ...`) so the audit trail matches what the user saw.
-
-> [!NOTE]
-> When `ephemeral=True`, the success branch wipes the screen as usual; `success_msg` is still recorded in the logfile. The failure branch surfaces `failure_msg` on stderr if provided, otherwise the original message.
-
-### Updating the completion message from inside the block
-
-When the success or failure text depends on work done inside the block (a count, a duration, the name of the item that failed), call `s.set_success()` or `s.set_failure()` on the yielded `Step`:
+When the success text depends on work done inside the block (a count, a duration, an output path), call `s.set_success_msg()` from inside the block:
 
 ```python
 with pp.step("compiling sources") as s:
     processed = []
-    try:
-        for path in sources:
-            compile_one(path)
-            processed.append(path)
-            s.sub(path.name)
-    except CompileError:
-        s.set_failure(f"aborted after {len(processed)} of {len(sources)} files")
-        raise
-    s.set_success(f"compiled {len(processed)} files")
+    for path in sources:
+        compile_one(path)
+        processed.append(path)
+        s.sub(path.name)
+    s.set_success_msg(f"compiled {len(processed)} files")
 ```
 
-The setter wins over the matching `success_msg` / `failure_msg` kwarg, which wins over the original message. Each setter takes its own `markup=` flag (defaults to `False`), so per-call escaping is independent of the `step(markup=...)` flag. The setter value also appears in the `succeeded:` / `failed:` logfile lines.
+The setter wins over the `success_msg` kwarg, which wins over the original message. Each takes its own `markup=` flag.
 
-`set_success()` is a no-op when the block raises; `set_failure()` is a no-op when the block returns normally.
+### Failing a step
 
-### Marking a step as skipped
-
-Some steps neither succeed nor fail: there was nothing to do, a precondition wasn't met, or the work was intentionally bypassed. Call `s.set_skipped()` from inside the block to render the completion with info-level styling (no checkmark, no error glyph) and log a `skipped:` line instead of `succeeded:`:
+When the work didn't succeed, call `s.fail(message)` from inside the block. This exits the `with` block immediately, replaces the spinner with an error marker, and writes a `failed:` line to the logfile:
 
 ```python
 with pp.step("compiling sources") as s:
-    if not sources:
-        s.set_skipped("no source files found")
-        return
     for path in sources:
+        if not path.exists():
+            s.fail(f"missing source: {path}")  # exits here
         compile_one(path)
+    s.set_success_msg(f"compiled {len(sources)} files")
 ```
 
-Pass the message inline, or pre-set it with `skip_msg=` and call `set_skipped()` with no arguments:
+Code after `s.fail(...)` inside the block does not run. To attach an exception's type and message to the `failed:` log line, pass `exception=`:
 
 ```python
-with pp.step("warming caches", skip_msg="caches already warm") as s:
+with pp.step("compiling sources") as s:
+    try:
+        compile_all(sources)
+    except CompileError as e:
+        s.fail("compilation aborted", exception=e)
+```
+
+> [!NOTE]
+> `s.fail()` is the only way to render the failure marker. An uncaught exception inside `step()` propagates through cleanly with no marker and no log line, leaving the original message visible (no spinner) and any sub-items intact. The caller owns error reporting in that path.
+
+When `ephemeral=True`, `s.fail()` still surfaces a fresh error line on stderr after wiping the spinner, so failures are never silently hidden:
+
+```python
+with pp.step("warming caches", ephemeral=True) as s:
+    if not cache_target_reachable():
+        s.fail("cache target unreachable")
+# stderr shows: ✗ cache target unreachable
+```
+
+### Skipping a step
+
+When the work the step describes did not run (nothing to do, preconditions unmet, intentional bypass), call `s.skip(message)`. This exits the `with` block immediately, replaces the spinner with an info-styled completion (no checkmark, no error glyph), and writes a `skipped:` line to the logfile:
+
+```python
+with pp.step("warming caches") as s:
     if cache.is_warm():
-        s.set_skipped()
-        return
+        s.skip("caches already warm")  # exits here
     warm_cache()
 ```
 
-`set_skipped()` (or the `skip_msg` kwarg) is a no-op until `set_skipped()` actually fires; without that call the block follows the success path as usual. The failure path takes precedence: if the block raises after `set_skipped()`, the step renders as failed. The setter value, kwarg, and original message follow the same precedence as the success path (setter > kwarg > original).
+Code after `s.skip(...)` does not run. Skip is not an error; in ephemeral mode it wipes the spinner with no extra console output.
 
 ## File logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@
             "S607",  # starting process with partial path (relying on PATH for git is intentional in tests)
             "SLF001",  # Access a private attribute
             "PT012",  # pytest.raises block multiple statements (legit when state must be set on a yielded object before raising)
+            "TRY301",  # Abstract `raise` to an inner function (tests intentionally raise inline to exercise real call sites)
         ], "duties.py" = ["ANN001", "FBT001", "FBT002"], "src/nclutils/pp/emitter.py" = [
             "ANN401", # Dynamically typed expressions (typing.Any) are disallowed in `**kwargs`
         ] }

--- a/skill/references/pp.md
+++ b/skill/references/pp.md
@@ -139,8 +139,6 @@ def step(
     ephemeral: bool = False,
     markup: bool = False,
     success_msg: str | RenderableType | None = None,
-    failure_msg: str | RenderableType | None = None,
-    skip_msg: str | RenderableType | None = None,
 ) -> Generator[Step]
 ```
 
@@ -155,23 +153,28 @@ The `Step` object yielded has four public methods:
 
 ```python
 Step.sub(text: str | Text, *, markup: bool = False) -> None
-Step.set_success(message: str | RenderableType, *, markup: bool = False) -> None
-Step.set_failure(message: str | RenderableType, *, markup: bool = False) -> None
-Step.set_skipped(message: str | RenderableType | None = None, *, markup: bool = False) -> None
+Step.set_success_msg(message: str | RenderableType, *, markup: bool = False) -> None
+Step.fail(message: str | RenderableType, *, exception: BaseException | bool = False, markup: bool = False) -> NoReturn
+Step.skip(message: str | RenderableType, *, markup: bool = False) -> NoReturn
 ```
 
 `sub()` appends a sub-item beneath the spinner. Strings are escaped by default; `markup=True` parses Rich markup. A `Text` instance keeps its own styling. Each sub-item is also written to the logfile (indented continuation line at `INFO`).
 
-`set_success()` / `set_failure()` update the completion header from inside the block when the text depends on work done there (a count, a duration, the item that failed). Setter wins over the matching kwarg, which wins over the original message. Each setter has its own `markup=` flag. The setter value also appears in the `succeeded:` / `failed:` log line. `set_success()` is ignored if the block raises; `set_failure()` is ignored if it returns normally.
+Outcome resolution:
 
-`set_skipped()` opts the step into a third outcome: the block did not run, but it didn't fail either (nothing to do, precondition unmet, intentional bypass). The completion header uses info-level styling (no checkmark) and the logfile records a `skipped:` line. The `message` argument is optional: if omitted, falls back to `skip_msg=` kwarg, then to the original step message. Ignored if the block raises (failure path wins).
+- Block exits normally → success outcome. Header uses `set_success_msg()` if called from inside the block, else the `success_msg=` kwarg, else the original `message`. Logfile records `succeeded: …`.
+- `s.fail(msg)` → exits the block, replaces the spinner with an error marker, writes `failed: …` to the logfile. Pass `exception=e` to attach the exception's type/message as a logfile continuation line. Code after the call inside the block does not execute.
+- `s.skip(msg)` → exits the block, replaces the spinner with an info-styled header (no checkmark), writes `skipped: …` to the logfile. Code after the call inside the block does not execute.
+- Any other exception escapes → propagates cleanly. No marker, no log line. The spinner is replaced with a plain static line so it does not stay frozen on screen; sub-items remain visible.
 
-On exit, the spinner resolves to `✓` (success), `✗` (failure), or the info-styled message (skipped). Any sub-items remain on screen. Exceptions inside the block (including `SystemExit` and `KeyboardInterrupt`) re-raise after marking failure.
+`set_success_msg()` is the dynamic counterpart to `success_msg=`: use it when the success text depends on work done inside the block (a count, a duration, an output path). The setter wins over the kwarg, which wins over the original message. Each carries its own `markup=` flag.
 
-- `ephemeral=True` wipes the spinner AND sub-items on success/skip; on failure the red X surfaces (and `failure_msg` / `set_failure()` value if set). Skip text still records in the logfile when ephemeral.
-- `success_msg=` / `failure_msg=` / `skip_msg=` override the resolved text; any can be omitted independently. The `step(markup=...)` flag covers all message kwargs, but setters carry their own per-call `markup=` flag.
-- `skip_msg=` alone does NOT trigger the skip outcome — `set_skipped()` must be called from inside the block to opt in. Without that call, the block follows the success path normally.
-- **`pp.step()` CANNOT NEST.** Rich's `Live` cannot stack — `pp` raises `RuntimeError` on nested entry on the same emitter. Use `s.sub("...")` for nested progress lines instead.
+`fail()` and `skip()` exit via an internal `BaseException` subclass, so a stray `except Exception:` inside the step body does not swallow them. Both require a message argument.
+
+- `ephemeral=True` wipes the spinner AND sub-items on success/skip with no extra console output. `s.fail()` still surfaces a fresh `✗ message` error line on stderr after the wipe so failures are not silently hidden. An uncaught exception in ephemeral mode leaves no console trace, the caller owns error reporting.
+- `success_msg=` overrides the success header at the call site; `set_success_msg()` overrides it dynamically from inside the block. The setter wins.
+- The `step(markup=...)` flag applies to `message` and `success_msg=`. Each setter (`set_success_msg`, `fail`, `skip`) carries its own per-call `markup=` flag.
+- **`pp.step()` CANNOT NEST.** Rich's `Live` cannot stack, `pp` raises `RuntimeError` on nested entry on the same emitter. Use `s.sub("...")` for nested progress lines instead.
 
 ## Configuration
 
@@ -388,13 +391,13 @@ dryrun(message, *, details=None, markup=False, style=None, detail_style=None, ma
 # Structural output
 header(message="", *, align="center", markup=False, **kwargs) -> None  # **kwargs forwarded to Console.rule()
 kv(items, *, indent=2, separator=": ", markup=False) -> None
-step(message, *, ephemeral=False, markup=False, success_msg=None, failure_msg=None, skip_msg=None) -> Generator[Step]
+step(message, *, ephemeral=False, markup=False, success_msg=None) -> Generator[Step]
 
 # Step API
 Step.sub(text, *, markup=False) -> None
-Step.set_success(message, *, markup=False) -> None
-Step.set_failure(message, *, markup=False) -> None
-Step.set_skipped(message=None, *, markup=False) -> None
+Step.set_success_msg(message, *, markup=False) -> None
+Step.fail(message, *, exception=False, markup=False) -> NoReturn
+Step.skip(message, *, markup=False) -> NoReturn
 
 # Configuration
 configure(*, verbosity=None, quiet=None, console=None, err_console=None, theme=None, logfile=None, loglevel=None, logfmt=None) -> None

--- a/skill/references/pp.md
+++ b/skill/references/pp.md
@@ -88,9 +88,9 @@ except UploadError:
 
 Outside an `except` block, `exception=True` is a silent no-op (matches `logging.exception()`). Pass `show_locals=True` for verbose dumps that include each frame's locals.
 
-`exception=` is accepted on every level method. `header()` and `step()` do NOT accept it — they manage their own exception display.
+`exception=` is accepted on every level method. `header()` and `step()` do NOT accept it. They manage their own exception display.
 
-## `pp.header()` — section rule
+## `pp.header()`: section rule
 
 ```python
 header(
@@ -104,12 +104,12 @@ header(
 
 `**kwargs` is forwarded to `Console.rule()`. Common ones:
 
-- `characters=` — glyph for the rule line (e.g. `"="`, `"-"`).
-- `style=` — Rich style for the line. Defaults to `"header.rule"` if you don't override.
+- `characters=`: glyph for the rule line (e.g. `"="`, `"-"`).
+- `style=`: Rich style for the line. Defaults to `"header.rule"` if you don't override.
 
-Unlike level methods, `message` is `str | Text` only (Console.rule has no meaning for a `Table` or `Panel` inline in a rule). Suppressed when `quiet=True`. NOT logged to the logfile — header is console-only structural sugar.
+Unlike level methods, `message` is `str | Text` only (Console.rule has no meaning for a `Table` or `Panel` inline in a rule). Suppressed when `quiet=True`. NOT logged to the logfile. Header is console-only structural sugar.
 
-## `pp.kv()` — aligned key/value block
+## `pp.kv()`: aligned key/value block
 
 ```python
 kv(
@@ -129,7 +129,7 @@ Renders aligned pairs. Keys are padded to the widest key's width; padded width =
 
 `pp.kv()` is suppressed on console by `quiet=True` (same as `pp.info`), but each pair is recorded as an `INFO` record in the logfile regardless. Multi-line values produce one log record per visual line, aligned with the key column. `markup=True` parses markup in string values; keys are always escaped.
 
-## `pp.step()` — spinner context manager
+## `pp.step()`: spinner context manager
 
 ```python
 @contextmanager
@@ -192,7 +192,7 @@ configure(
 ) -> None
 ```
 
-Partial update of the shared default emitter. Fields you don't pass are left alone — passing `logfile=None` is a NO-OP, not a way to disable the logfile. To stop logging, build a fresh emitter: `pp.set_default(pp.Emitter())`.
+Partial update of the shared default emitter. Fields you don't pass are left alone. Passing `logfile=None` is a NO-OP, not a way to disable the logfile. To stop logging, build a fresh emitter: `pp.set_default(pp.Emitter())`.
 
 ```python
 pp.configure(
@@ -292,9 +292,9 @@ Field semantics:
 - `Level.marker=""` (empty string) is a REAL value meaning "no marker". Only `None` falls back to the default. Same for empty-string `style`/`detail_style`.
 - `Theme.<level> = None` keeps that level's defaults entirely.
 
-Successive `pp.configure(theme=...)` calls ACCUMULATE at the field level — overrides are not reset between calls. To fully reset, build a fresh emitter: `pp.set_default(pp.Emitter())`.
+Successive `pp.configure(theme=...)` calls ACCUMULATE at the field level. Overrides are not reset between calls. To fully reset, build a fresh emitter: `pp.set_default(pp.Emitter())`.
 
-**Not themable.** The `pp.header()` rule, the `[dry-run]` tag, and the tree connector glyphs (`├─` / `└─` / `│`). Connectors share the `sub.pipe` Rich theme key for STYLE only — to change the connector glyph itself, build a custom `Console(theme=...)`.
+**Not themable.** The `pp.header()` rule, the `[dry-run]` tag, and the tree connector glyphs (`├─` / `└─` / `│`). Connectors share the `sub.pipe` Rich theme key for STYLE only. To change the connector glyph itself, build a custom `Console(theme=...)`.
 
 Default styles (read-only, from source):
 
@@ -311,7 +311,7 @@ Default styles (read-only, from source):
 
 ## ASCII fallback
 
-`pp` probes `console.encoding` once per encoding (memoized in `_ASCII_REQUIRED_CACHE`) and falls back to ASCII when unicode glyphs can't render (e.g. `LANG=C`, `PYTHONIOENCODING=ascii`, Windows code-page rejection). Tree connectors collapse to `- `; default markers map per the table above. User-supplied `Theme(level=Level(marker=...))` markers are ALWAYS respected verbatim, ASCII or not — only built-in defaults get substituted.
+`pp` probes `console.encoding` once per encoding (memoized in `_ASCII_REQUIRED_CACHE`) and falls back to ASCII when unicode glyphs can't render (e.g. `LANG=C`, `PYTHONIOENCODING=ascii`, Windows code-page rejection). Tree connectors collapse to `- `; default markers map per the table above. User-supplied `Theme(level=Level(marker=...))` markers are ALWAYS respected verbatim, ASCII or not. Only built-in defaults get substituted.
 
 ## File logging
 
@@ -373,7 +373,7 @@ pp.console().print(table)
 pp.err_console().print("[bold red]fatal[/]")
 ```
 
-`pp.console()` and `pp.err_console()` re-resolve on each call — they read from the current default emitter, so `set_default()` swaps take effect immediately.
+`pp.console()` and `pp.err_console()` re-resolve on each call, reading from the current default emitter, so `set_default()` swaps take effect immediately.
 
 ## API reference (signatures only)
 

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -480,7 +480,7 @@ class _StepExit(BaseException):
         markup: bool,
         exception: BaseException | bool = False,
     ) -> None:
-        super().__init__()
+        super().__init__(outcome, message)
         self.outcome = outcome
         self.message = message
         self.markup = markup
@@ -606,7 +606,7 @@ class Step:
                 grab `sys.exc_info()`. Defaults to `False` (nothing attached).
             markup: When True, parses Rich markup in a `str` `message`.
         """
-        raise _StepExit("failure", message, markup=markup, exception=exception)  # noqa: EM101 -- discriminant literal, not an error message
+        raise _StepExit("failure", message, markup=markup, exception=exception)  # noqa: EM101  # first positional arg is the discriminant, not an error message
 
     def skip(
         self,
@@ -627,7 +627,7 @@ class Step:
                 renderables pass through.
             markup: When True, parses Rich markup in a `str` `message`.
         """
-        raise _StepExit("skip", message, markup=markup)  # noqa: EM101 -- discriminant literal, not an error message
+        raise _StepExit("skip", message, markup=markup)  # noqa: EM101  # first positional arg is the discriminant, not an error message
 
     def set_completion(self, completion: _StepCompletion) -> None:
         """Record completion state so __rich_console__ rebuilds the header with ASCII fallback.
@@ -1586,7 +1586,10 @@ class Emitter:
         by the message in the success style. On any exception (including
         typer.Exit), prints the error marker then re-raises. Sub-items added
         via `Step.sub()` render beneath the spinner during the step and remain
-        on screen beneath the final marker.
+        on screen beneath the final marker. Calling `s.fail(msg)` or
+        `s.skip(msg)` from inside the block exits early via an internal
+        sentinel and renders the corresponding outcome; see `Step.fail` and
+        `Step.skip` for details.
 
         When `ephemeral` is True the spinner and sub-items are cleared from the
         console on completion. Success leaves no trace; failure prints only the

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -15,7 +15,7 @@ import time
 import traceback as _traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NoReturn
 
 from rich.console import Console
 from rich.live import Live
@@ -462,6 +462,31 @@ def _resolve_step_message(
     return default_message, default_markup
 
 
+class _StepExit(BaseException):
+    """Internal control-flow signal raised by `Step.fail()` / `Step.skip()`.
+
+    Subclasses `BaseException` (not `Exception`) so a stray `except Exception:`
+    inside the step body does not swallow it. `Emitter.step()` catches it
+    specifically and dispatches to the matching outcome path.
+    """
+
+    __slots__ = ("exception", "markup", "message", "outcome")
+
+    def __init__(
+        self,
+        outcome: Literal["failure", "skip"],
+        message: str | RenderableType,
+        *,
+        markup: bool,
+        exception: BaseException | bool = False,
+    ) -> None:
+        super().__init__()
+        self.outcome = outcome
+        self.message = message
+        self.markup = markup
+        self.exception = exception
+
+
 @dataclass(frozen=True, slots=True)
 class _StepCompletion:
     """Completion state recorded by `step()` and rendered by `Step.__rich_console__`.
@@ -556,6 +581,53 @@ class Step:
         self.is_skipped = True
         if message is not None:
             self.skip_override = (message, markup)
+
+    def fail(
+        self,
+        message: str | RenderableType,
+        *,
+        exception: BaseException | bool = False,
+        markup: bool = False,
+    ) -> NoReturn:
+        """End the step with a failure outcome.
+
+        Renders the error marker on the spinner line in place, writes a
+        `failed:` line to the logfile, and exits the `with` block. Code after
+        the call inside the block does not execute. Pass `exception=` to attach
+        the exception type/message (or active traceback when `True`) as a
+        logfile continuation line.
+
+        Args:
+            message: Failure header text. Strings are escaped unless
+                `markup=True`; `Text` keeps its own styling; other Rich
+                renderables pass through.
+            exception: Optional exception to attach to the `failed:` log line.
+                Pass an instance, or `True` from inside an `except` block to
+                grab `sys.exc_info()`. Defaults to `False` (nothing attached).
+            markup: When True, parses Rich markup in a `str` `message`.
+        """
+        raise _StepExit("failure", message, markup=markup, exception=exception)  # noqa: EM101 -- discriminant literal, not an error message
+
+    def skip(
+        self,
+        message: str | RenderableType,
+        *,
+        markup: bool = False,
+    ) -> NoReturn:
+        """End the step with a skip outcome.
+
+        Use when the work the step describes did not run (nothing to do,
+        preconditions unmet) but the situation is not an error. Renders an
+        info-styled completion header (no checkmark, no error glyph), writes a
+        `skipped:` line to the logfile, and exits the `with` block.
+
+        Args:
+            message: Skip header text. Strings are escaped unless
+                `markup=True`; `Text` keeps its own styling; other Rich
+                renderables pass through.
+            markup: When True, parses Rich markup in a `str` `message`.
+        """
+        raise _StepExit("skip", message, markup=markup)  # noqa: EM101 -- discriminant literal, not an error message
 
     def set_completion(self, completion: _StepCompletion) -> None:
         """Record completion state so __rich_console__ rebuilds the header with ASCII fallback.
@@ -1498,7 +1570,7 @@ class Emitter:
         self.console.print(_KVBlock(pair_list, indent=indent, separator=separator, markup=markup))
 
     @contextmanager
-    def step(
+    def step(  # noqa: C901, PLR0912, PLR0915 -- transitional: new _StepExit branch coexists with auto-failure path; trimmed in follow-up
         self,
         message: str | RenderableType,
         *,
@@ -1579,6 +1651,50 @@ class Emitter:
             with Live(s, console=self.console, refresh_per_second=12.5, transient=ephemeral):
                 try:
                     yield s
+                except _StepExit as exit_signal:
+                    if exit_signal.outcome == "failure":
+                        if not ephemeral:
+                            s.set_completion(
+                                _StepCompletion(
+                                    level_name="error",
+                                    message=exit_signal.message,
+                                    style=error_style,
+                                    marker=error_marker,
+                                    markup=exit_signal.markup,
+                                )
+                            )
+                        failure_text = _message_to_log_text(
+                            exit_signal.message, markup=exit_signal.markup
+                        )
+                        log_details = _format_exception_for_logfile(exit_signal.exception)
+                        self._logsink.emit(
+                            level=_LEVEL_TO_LOG_SEVERITY["error"],
+                            message=f"failed: {failure_text}",
+                            details=log_details,
+                        )
+                        if ephemeral:
+                            self.error(exit_signal.message, markup=exit_signal.markup)
+                        return
+                    # skip outcome: we've already written our own log line, so we
+                    # return out of `with Live(...)` instead of falling through to
+                    # the natural success bookkeeping below.
+                    if not ephemeral:
+                        s.set_completion(
+                            _StepCompletion(
+                                level_name="info",
+                                message=exit_signal.message,
+                                style=info_style,
+                                marker=info_marker,
+                                markup=exit_signal.markup,
+                            )
+                        )
+                    skip_text = _message_to_log_text(exit_signal.message, markup=exit_signal.markup)
+                    self._logsink.emit(
+                        level=_LEVEL_TO_LOG_SEVERITY["info"],
+                        message=f"skipped: {skip_text}",
+                        details=None,
+                    )
+                    return
                 except BaseException as exc:
                     failure_message, failure_markup = _resolve_step_message(
                         s.failure_override, failure_msg, message, default_markup=markup

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -522,13 +522,15 @@ class Step:
         self._subs: list[Text] = []
         self._logsink: _LogSink | None = logsink
         self._completion: _StepCompletion | None = None
-        self.success_override: tuple[str | RenderableType, bool] | None = None
+        self.success_msg_override: tuple[str | RenderableType, bool] | None = None
 
-    def set_success(self, message: str | RenderableType, *, markup: bool = False) -> None:
+    def set_success_msg(self, message: str | RenderableType, *, markup: bool = False) -> None:
         """Override the success header from inside the `step()` block.
 
-        Takes precedence over the `success_msg` kwarg on `step()`. No effect
-        if the block raises.
+        Does NOT exit. Recorded and applied when the block exits normally.
+        Takes precedence over the `success_msg=` kwarg on `step()`.
+        Ignored if the block exits via `fail()`, `skip()`, or an uncaught
+        exception.
 
         Args:
             message: Replacement success header. Strings are escaped unless
@@ -536,7 +538,7 @@ class Step:
                 renderables pass through.
             markup: When True, parses Rich markup in a `str` `message`.
         """
-        self.success_override = (message, markup)
+        self.success_msg_override = (message, markup)
 
     def fail(
         self,
@@ -1554,10 +1556,10 @@ class Emitter:
         prints a visible error line on stderr after wiping.
 
         `success_msg` overrides the success-state header; defaults to the
-        original `message` styled as success. The single `markup=` flag covers
-        all message kwargs. The succeeded: log line also uses the override
-        message when provided so the audit trail matches what the user saw on
-        the console.
+        original `message` styled as success. The `markup=` flag applies to
+        both `message` and `success_msg`. The succeeded: log line also uses
+        the override message when provided so the audit trail matches what
+        the user saw on the console.
 
         Args:
             message: Title shown next to the spinner. Strings are escaped by
@@ -1568,10 +1570,14 @@ class Emitter:
             markup: When True, parses Rich markup in a `str` `message`
                 instead of escaping.
             success_msg: Optional message to display on success in place of
-                the original `message`. Falls back to `message` when None.
+                the original `message`. Falls back to `message` when None,
+                and is overridden by `set_success_msg()` called from inside
+                the block.
 
         Yields:
-            A `Step` whose `sub()` method appends sub-items beneath the spinner.
+            A `Step` whose `sub()` method appends sub-items beneath the spinner,
+            and whose `fail()`/`skip()`/`set_success_msg()` methods control the
+            outcome.
 
         Raises:
             RuntimeError: If called inside another `step()` on the same emitter;
@@ -1658,7 +1664,7 @@ class Emitter:
                         )
                     raise
                 outcome_message, outcome_markup = _resolve_step_message(
-                    s.success_override, success_msg, message, default_markup=markup
+                    s.success_msg_override, success_msg, message, default_markup=markup
                 )
                 if not ephemeral:
                     s.set_completion(

--- a/src/nclutils/pp/emitter.py
+++ b/src/nclutils/pp/emitter.py
@@ -523,9 +523,6 @@ class Step:
         self._logsink: _LogSink | None = logsink
         self._completion: _StepCompletion | None = None
         self.success_override: tuple[str | RenderableType, bool] | None = None
-        self.failure_override: tuple[str | RenderableType, bool] | None = None
-        self.skip_override: tuple[str | RenderableType, bool] | None = None
-        self.is_skipped: bool = False
 
     def set_success(self, message: str | RenderableType, *, markup: bool = False) -> None:
         """Override the success header from inside the `step()` block.
@@ -540,47 +537,6 @@ class Step:
             markup: When True, parses Rich markup in a `str` `message`.
         """
         self.success_override = (message, markup)
-
-    def set_failure(self, message: str | RenderableType, *, markup: bool = False) -> None:
-        """Override the failure header from inside the `step()` block.
-
-        Takes precedence over the `failure_msg` kwarg on `step()`. No effect
-        if the block completes normally.
-
-        Args:
-            message: Replacement failure header. Strings are escaped unless
-                `markup=True`; `Text` keeps its own styling; other Rich
-                renderables pass through.
-            markup: When True, parses Rich markup in a `str` `message`.
-        """
-        self.failure_override = (message, markup)
-
-    def set_skipped(
-        self,
-        message: str | RenderableType | None = None,
-        *,
-        markup: bool = False,
-    ) -> None:
-        """Mark the step as skipped instead of succeeded on normal block exit.
-
-        Use when the work the step describes did not run (for example, nothing
-        to do, preconditions unmet) but the situation is not an error. The
-        completion header renders with info-level styling and no checkmark, and
-        the logfile records a `skipped:` line instead of `succeeded:`.
-
-        If `message` is omitted, the header falls back to the `skip_msg`
-        kwarg on `step()`, then to the original step message. Has no effect
-        if the block raises (the failure path takes precedence).
-
-        Args:
-            message: Optional replacement header. Strings are escaped unless
-                `markup=True`; `Text` keeps its own styling; other Rich
-                renderables pass through.
-            markup: When True, parses Rich markup in a `str` `message`.
-        """
-        self.is_skipped = True
-        if message is not None:
-            self.skip_override = (message, markup)
 
     def fail(
         self,
@@ -1570,46 +1526,38 @@ class Emitter:
         self.console.print(_KVBlock(pair_list, indent=indent, separator=separator, markup=markup))
 
     @contextmanager
-    def step(  # noqa: C901, PLR0912, PLR0915 -- transitional: new _StepExit branch coexists with auto-failure path; trimmed in follow-up
+    def step(
         self,
         message: str | RenderableType,
         *,
         ephemeral: bool = False,
         markup: bool = False,
         success_msg: str | RenderableType | None = None,
-        failure_msg: str | RenderableType | None = None,
-        skip_msg: str | RenderableType | None = None,
     ) -> Generator[Step]:
         """Show a spinner while the block runs, then a completion marker.
 
-        On success, prints the customized (or default) success marker followed
-        by the message in the success style. On any exception (including
-        typer.Exit), prints the error marker then re-raises. Sub-items added
-        via `Step.sub()` render beneath the spinner during the step and remain
-        on screen beneath the final marker. Calling `s.fail(msg)` or
-        `s.skip(msg)` from inside the block exits early via an internal
-        sentinel and renders the corresponding outcome; see `Step.fail` and
-        `Step.skip` for details.
+        On natural completion, prints the success marker followed by the
+        message in the success style. Sub-items added via `Step.sub()` render
+        beneath the spinner during the step and remain on screen beneath the
+        final marker. Calling `s.fail(msg)` or `s.skip(msg)` from inside the
+        block exits early via an internal sentinel and renders the
+        corresponding outcome; see `Step.fail` and `Step.skip` for details.
+
+        An uncaught exception inside the block propagates to the caller with
+        no failure marker, no error styling, and no `failed:` log line. The
+        spinner is neutralized so Live does not freeze on screen, but the
+        caller owns error reporting. To attach a marker and log line for a
+        recoverable failure, catch the exception and call `s.fail(...)`.
 
         When `ephemeral` is True the spinner and sub-items are cleared from the
-        console on completion. Success leaves no trace; failure prints only the
-        error marker so errors are not silently hidden.
-
-        The block can opt the step into a third "skipped" outcome by calling
-        `Step.set_skipped()` from inside the `with`. A skipped step renders
-        with info-level styling (no checkmark) and writes a `skipped:` line to
-        the logfile instead of `succeeded:`. The `skip_msg` kwarg supplies the
-        default header text for that outcome and only takes effect when
-        `set_skipped()` fires (it does not trigger the skip path on its own).
+        console on completion. Natural success leaves no trace; `s.fail()`
+        prints a visible error line on stderr after wiping.
 
         `success_msg` overrides the success-state header; defaults to the
-        original `message` styled as success. `failure_msg` overrides the
-        failure-state header; defaults to the original `message` styled as
-        error. `skip_msg` overrides the skipped-state header; defaults to the
-        original `message`. Any side may be omitted independently. The single
-        `markup=` flag covers all message kwargs. The succeeded:/failed:/skipped:
-        log lines also use the override messages when provided so the audit
-        trail matches what the user saw on the console.
+        original `message` styled as success. The single `markup=` flag covers
+        all message kwargs. The succeeded: log line also uses the override
+        message when provided so the audit trail matches what the user saw on
+        the console.
 
         Args:
             message: Title shown next to the spinner. Strings are escaped by
@@ -1621,11 +1569,6 @@ class Emitter:
                 instead of escaping.
             success_msg: Optional message to display on success in place of
                 the original `message`. Falls back to `message` when None.
-            failure_msg: Optional message to display on failure in place of
-                the original `message`. Falls back to `message` when None.
-            skip_msg: Optional message to display on skip in place of the
-                original `message`. Only used when `Step.set_skipped()` is
-                called from inside the block. Falls back to `message` when None.
 
         Yields:
             A `Step` whose `sub()` method appends sub-items beneath the spinner.
@@ -1698,62 +1641,38 @@ class Emitter:
                         details=None,
                     )
                     return
-                except BaseException as exc:
-                    failure_message, failure_markup = _resolve_step_message(
-                        s.failure_override, failure_msg, message, default_markup=markup
-                    )
+                except BaseException:
+                    # Caller-owned failure reporting: step() never auto-captures
+                    # exceptions. Replace the spinner with a plain static line so
+                    # Live doesn't freeze the spinner glyph on screen, then
+                    # propagate. No marker. No log line.
                     if not ephemeral:
-                        # Defer header construction to Step.__rich_console__ so
-                        # ASCII marker substitution sees the live console encoding.
                         s.set_completion(
                             _StepCompletion(
-                                level_name="error",
-                                message=failure_message,
-                                style=error_style,
-                                marker=error_marker,
-                                markup=failure_markup,
+                                level_name="info",
+                                message=message,
+                                style=info_style,
+                                marker="",
+                                markup=markup,
                             )
                         )
-                    failure_text = _message_to_log_text(failure_message, markup=failure_markup)
-                    self._logsink.emit(
-                        level=_LEVEL_TO_LOG_SEVERITY["error"],
-                        message=f"failed: {failure_text}",
-                        details=[f"{type(exc).__name__}: {exc}"],
-                    )
-                    if ephemeral:
-                        # Pass the original renderable (not the plain-text strip) so styling/markup is preserved.
-                        self.error(failure_message)
                     raise
-                if s.is_skipped:
-                    outcome_level: LevelName = "info"
-                    outcome_style = info_style
-                    outcome_marker = info_marker
-                    outcome_override = s.skip_override
-                    outcome_kwarg = skip_msg
-                    log_verb = "skipped"
-                else:
-                    outcome_level = "success"
-                    outcome_style = success_style
-                    outcome_marker = success_marker
-                    outcome_override = s.success_override
-                    outcome_kwarg = success_msg
-                    log_verb = "succeeded"
                 outcome_message, outcome_markup = _resolve_step_message(
-                    outcome_override, outcome_kwarg, message, default_markup=markup
+                    s.success_override, success_msg, message, default_markup=markup
                 )
                 if not ephemeral:
                     s.set_completion(
                         _StepCompletion(
-                            level_name=outcome_level,
+                            level_name="success",
                             message=outcome_message,
-                            style=outcome_style,
-                            marker=outcome_marker,
+                            style=success_style,
+                            marker=success_marker,
                             markup=outcome_markup,
                         )
                     )
             self._logsink.emit(
-                level=_LEVEL_TO_LOG_SEVERITY[outcome_level],
-                message=f"{log_verb}: {_message_to_log_text(outcome_message, markup=outcome_markup)}",
+                level=_LEVEL_TO_LOG_SEVERITY["success"],
+                message=f"succeeded: {_message_to_log_text(outcome_message, markup=outcome_markup)}",
                 details=None,
             )
         finally:
@@ -2132,20 +2051,17 @@ def step(
     ephemeral: bool = False,
     markup: bool = False,
     success_msg: str | RenderableType | None = None,
-    failure_msg: str | RenderableType | None = None,
-    skip_msg: str | RenderableType | None = None,
 ) -> Generator[Step]:
     """Run a spinner-driven step on the default emitter.
 
-    See `Emitter.step` for `message`/`markup`/`success_msg`/`failure_msg`/`skip_msg` semantics.
+    See `Emitter.step` for `message`/`markup`/`success_msg` semantics and the
+    outcome-resolution contract.
     """
     with _default.step(
         message,
         ephemeral=ephemeral,
         markup=markup,
         success_msg=success_msg,
-        failure_msg=failure_msg,
-        skip_msg=skip_msg,
     ) as s:
         yield s
 

--- a/tests/pp/test_ascii_fallback.py
+++ b/tests/pp/test_ascii_fallback.py
@@ -147,10 +147,9 @@ class TestAsciiStepHeader:
         # Given an ASCII-encoding emitter
         e, out, _ = _make_ascii_emitter()
 
-        # When step() raises (non-ephemeral)
-        err_msg = "boom"
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling"):
-            raise RuntimeError(err_msg)
+        # When step() exits via fail() (non-ephemeral)
+        with e.step("compiling") as s:
+            s.fail("compiling")
 
         # Then the failure line uses the ASCII error marker, not the unicode one
         text = out.export_text()

--- a/tests/pp/test_emitter.py
+++ b/tests/pp/test_emitter.py
@@ -304,14 +304,13 @@ class TestStepLifecycle:
     def test_ephemeral_failure_emits_error_to_stderr(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify ephemeral failure clears the spinner but surfaces an error on stderr."""
+        """Verify ephemeral fail() clears the spinner but surfaces an error on stderr."""
         # Given a default Emitter wired to recording consoles
         e, _, err = make_recording_emitter()
 
-        # When an ephemeral step body raises
-        err_msg = "boom"
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling", ephemeral=True):
-            raise RuntimeError(err_msg)
+        # When an ephemeral step calls fail()
+        with e.step("compiling", ephemeral=True) as s:
+            s.fail("compiling")
 
         # Then an error with the step message lands on stderr with the default error marker
         err_text = err.export_text()

--- a/tests/pp/test_exception.py
+++ b/tests/pp/test_exception.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 def _capture(exc_cls: type[BaseException], message: str) -> BaseException:
     """Raise `exc_cls(message)`, catch it, and return the captured instance with a traceback."""
     try:
-        raise exc_cls(message)  # noqa: TRY301 -- inner raise IS the test setup; cannot abstract further
+        raise exc_cls(message)
     except BaseException as exc:  # noqa: BLE001 -- intentional broad catch to relay any subtype
         return exc
 
@@ -96,7 +96,7 @@ class TestExceptionTrue:
         # When error is called with exception=True inside an except block
         try:
             msg = "boom"
-            raise ValueError(msg)  # noqa: TRY301 -- direct raise required to populate sys.exc_info
+            raise ValueError(msg)
         except ValueError:
             e.error("operation failed", exception=True)
 
@@ -282,7 +282,7 @@ class TestExceptionLogfile:
         # When an exception with brackets in its message is logged
         try:
             msg = "['missing_key']"
-            raise KeyError(msg)  # noqa: TRY301 -- inline raise required to populate the traceback
+            raise KeyError(msg)
         except KeyError as exc:
             e.error("lookup failed", exception=exc)
 

--- a/tests/pp/test_logfile.py
+++ b/tests/pp/test_logfile.py
@@ -481,13 +481,16 @@ class TestStepLifecycleInLogfile:
     def test_step_failure_writes_starting_and_failed_with_continuation(
         self, tmp_path: Path
     ) -> None:
-        """Verify a failing step writes 'starting:' then 'failed:' at ERROR with the exception as a continuation."""
+        """Verify a step calling fail(exception=) writes 'starting:' then 'failed:' at ERROR with the exception as a continuation."""
         path = tmp_path / "run.log"
         e = Emitter(logfile=path)
 
         msg = "boom"
-        with pytest.raises(RuntimeError, match=msg), e.step("flaky thing"):
-            raise RuntimeError(msg)
+        with e.step("flaky thing") as s:
+            try:
+                raise RuntimeError(msg)
+            except RuntimeError as caught:
+                s.fail("flaky thing", exception=caught)
 
         lines = path.read_text(encoding="utf-8").splitlines()
         assert any("starting: flaky thing" in line and "INFO" in line for line in lines)

--- a/tests/pp/test_step_msgs.py
+++ b/tests/pp/test_step_msgs.py
@@ -797,3 +797,210 @@ class TestModuleLevelStepSkip:
         # Then the kwarg message appears in the rendered output
         text = out.export_text()
         assert "nothing to compile" in text
+
+
+class TestStepFail:
+    """`Step.fail()` exits the block with failure outcome."""
+
+    def test_fail_exits_the_block(self, make_recording_emitter: RecordingEmitterFactory) -> None:
+        """Verify fail() ends the with-block immediately; code after the call does not run."""
+        # Given an emitter
+        e, _, _ = make_recording_emitter()
+        after_fail_ran = False
+
+        # When fail() is called inside the block
+        with e.step("compiling") as s:
+            s.fail("aborted")
+            after_fail_ran = True  # should be unreachable
+
+        # Then code after fail() did not execute and the block ended normally
+        assert after_fail_ran is False
+
+    def test_fail_renders_error_header(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify fail() replaces the spinner with an error-marker completion header."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+
+        # When fail() is called inside the block
+        with e.step("compiling") as s:
+            s.fail("aborted after 17 files")
+
+        # Then the failure message appears with the error marker on the recorded output
+        text = out.export_text()
+        assert "aborted after 17 files" in text
+        assert "✗" in text  # default unicode error marker
+
+    def test_fail_writes_failed_log_line(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify fail() records a `failed:` line in the logfile."""
+        # Given an emitter with a logfile
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When fail() is called
+        with e.step("compiling") as s:
+            s.fail("aborted")
+
+        # Then the logfile contains the failed: line
+        contents = logfile.read_text()
+        assert "failed: aborted" in contents
+
+    def test_fail_with_exception_attaches_traceback_to_log(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify fail(exception=e) attaches the exception type/message as a logfile continuation line."""
+        # Given an emitter with a logfile and a real exception to attach
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When the block catches an exception and calls fail(exception=...)
+        err_msg = "bad input"
+        with e.step("compiling") as s:
+            try:
+                raise ValueError(err_msg)  # noqa: TRY301
+            except ValueError as caught:
+                s.fail("compilation failed", exception=caught)
+
+        # Then the logfile contains the exception type and message as a continuation
+        contents = logfile.read_text()
+        assert "failed: compilation failed" in contents
+        assert "ValueError" in contents
+        assert "bad input" in contents
+
+    def test_fail_in_ephemeral_prints_visible_error_line(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify fail() in ephemeral mode surfaces a fresh error line on stderr after wiping."""
+        # Given an emitter with recording stderr in ephemeral mode
+        e, _, err = make_recording_emitter()
+
+        # When fail() is called inside an ephemeral step
+        with e.step("warming caches", ephemeral=True) as s:
+            s.fail("cache priming failed")
+
+        # Then a visible error line lands on stderr
+        err_text = err.export_text()
+        assert "cache priming failed" in err_text
+        assert "✗" in err_text  # default unicode error marker
+
+    def test_fail_markup_parses_tags(self, make_recording_emitter: RecordingEmitterFactory) -> None:
+        """Verify fail(markup=True) parses Rich markup in the message."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+
+        # When fail() is called with markup-containing message and markup=True
+        with e.step("compiling") as s:
+            s.fail("[bold]aborted[/]", markup=True)
+
+        # Then the rendered output contains the message text but not the literal markup tags
+        text = out.export_text()
+        assert "aborted" in text
+        assert "[bold]" not in text
+
+    def test_fail_requires_message(self, make_recording_emitter: RecordingEmitterFactory) -> None:
+        """Verify fail() without a message argument is a TypeError."""
+        # Given an emitter
+        e, _, _ = make_recording_emitter()
+
+        # When fail() is called without a message
+        # Then a TypeError is raised
+        with pytest.raises(TypeError), e.step("compiling") as s:
+            s.fail()  # type: ignore[call-arg]
+
+
+class TestStepSkip:
+    """`Step.skip()` exits the block with skip outcome."""
+
+    def test_skip_exits_the_block(self, make_recording_emitter: RecordingEmitterFactory) -> None:
+        """Verify skip() ends the with-block immediately; code after the call does not run."""
+        # Given an emitter
+        e, _, _ = make_recording_emitter()
+        after_skip_ran = False
+
+        # When skip() is called inside the block
+        with e.step("warming caches") as s:
+            s.skip("already warm")
+            after_skip_ran = True  # should be unreachable
+
+        # Then code after skip() did not execute
+        assert after_skip_ran is False
+
+    def test_skip_renders_info_header_no_checkmark(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify skip() replaces the spinner with an info-styled completion (no checkmark)."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+
+        # When skip() is called inside the block
+        with e.step("warming caches") as s:
+            s.skip("already warm")
+
+        # Then the skip message appears without the success checkmark
+        text = out.export_text()
+        assert "already warm" in text
+        assert "✓" not in text  # default unicode success marker
+
+    def test_skip_writes_skipped_log_line(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify skip() records a `skipped:` line in the logfile."""
+        # Given an emitter with a logfile
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+
+        # When skip() is called
+        with e.step("warming caches") as s:
+            s.skip("already warm")
+
+        # Then the logfile contains the skipped: line
+        contents = logfile.read_text()
+        assert "skipped: already warm" in contents
+
+    def test_skip_in_ephemeral_wipes_no_extra_output(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify skip() in ephemeral mode wipes everything and prints no extra line."""
+        # Given an emitter with recording streams
+        e, _, err = make_recording_emitter()
+
+        # When skip() is called inside an ephemeral step
+        with e.step("warming caches", ephemeral=True) as s:
+            s.skip("already warm")
+
+        # Then no extra stderr error line is produced (skip is not an error)
+        err_text = err.export_text()
+        assert "already warm" not in err_text
+
+    def test_skip_markup_parses_tags(self, make_recording_emitter: RecordingEmitterFactory) -> None:
+        """Verify skip(markup=True) parses Rich markup in the message."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+
+        # When skip() is called with markup-containing message
+        with e.step("warming caches") as s:
+            s.skip("[bold]already warm[/]", markup=True)
+
+        # Then the rendered output contains the message text but not the literal tags
+        text = out.export_text()
+        assert "already warm" in text
+        assert "[bold]" not in text
+
+    def test_skip_requires_message(self, make_recording_emitter: RecordingEmitterFactory) -> None:
+        """Verify skip() without a message argument is a TypeError."""
+        # Given an emitter
+        e, _, _ = make_recording_emitter()
+
+        # When skip() is called without a message
+        # Then a TypeError is raised
+        with pytest.raises(TypeError), e.step("warming caches") as s:
+            s.skip()  # type: ignore[call-arg]

--- a/tests/pp/test_step_msgs.py
+++ b/tests/pp/test_step_msgs.py
@@ -1,4 +1,4 @@
-"""Tests for step() success_msg and failure_msg kwargs."""
+"""Tests for step() success_msg kwarg and outcome-control APIs."""
 
 from __future__ import annotations
 
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 from rich.padding import Padding
-from rich.text import Text
 
 from nclutils.pp import emitter as pp_emitter
 
@@ -65,45 +64,6 @@ class TestStepSuccessMsg:
         assert "compiled 42 files" in text
 
 
-class TestStepFailureMsg:
-    """`failure_msg` swaps the error header text on exception."""
-
-    def test_failure_msg_replaces_header_on_exception(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify failure_msg appears in place of the original message on exception."""
-        # Given an emitter wired to a recording console
-        e, out, _ = make_recording_emitter()
-        err_msg = "boom"
-
-        # When step() raises with a failure_msg override
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step("compiling", failure_msg="compilation aborted"),
-        ):
-            raise RuntimeError(err_msg)
-
-        # Then the failure_msg appears in the rendered output
-        text = out.export_text()
-        assert "compilation aborted" in text
-
-    def test_failure_msg_default_keeps_original(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify omitting failure_msg preserves current behavior (original message kept)."""
-        # Given an emitter wired to a recording console
-        e, out, _ = make_recording_emitter()
-        err_msg = "boom"
-
-        # When step() raises without override kwargs
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling"):
-            raise RuntimeError(err_msg)
-
-        # Then the original message appears in the failure line
-        text = out.export_text()
-        assert "compiling" in text
-
-
 class TestStepLogfile:
     """Override messages are recorded in the logfile lifecycle records."""
 
@@ -124,28 +84,6 @@ class TestStepLogfile:
         # Then the logfile records the override message in the succeeded: line
         contents = logfile.read_text()
         assert "succeeded: compiled 42 files" in contents
-
-    def test_failure_msg_in_logfile(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify the failed: line in the logfile uses failure_msg when provided."""
-        # Given an emitter with a logfile
-        logfile = tmp_path / "run.log"
-        e, _, _ = make_recording_emitter(logfile=logfile)
-        err_msg = "boom"
-
-        # When step() raises with an override
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step("compiling", failure_msg="compilation aborted"),
-        ):
-            raise RuntimeError(err_msg)
-
-        # Then the logfile records the override message in the failed: line
-        contents = logfile.read_text()
-        assert "failed: compilation aborted" in contents
 
     def test_success_default_logs_original_message(
         self,
@@ -187,73 +125,6 @@ class TestEphemeralStepInteraction:
         contents = logfile.read_text()
         assert "succeeded: caches warm" in contents
 
-    def test_ephemeral_failure_displays_failure_msg(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-    ) -> None:
-        """Verify ephemeral failure surfaces failure_msg on stderr."""
-        # Given an emitter wired to recording stderr
-        e, _, err = make_recording_emitter()
-        err_msg = "boom"
-
-        # When step() raises in ephemeral mode with a failure_msg
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step(
-                "warming caches",
-                ephemeral=True,
-                failure_msg="cache priming failed",
-            ),
-        ):
-            raise RuntimeError(err_msg)
-
-        # Then the failure_msg appears in the surfaced error output
-        text = err.export_text()
-        assert "cache priming failed" in text
-
-    def test_ephemeral_failure_default_surfaces_original(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-    ) -> None:
-        """Verify ephemeral failure falls back to the original message on stderr without override."""
-        # Given an emitter wired to recording stderr
-        e, _, err = make_recording_emitter()
-        err_msg = "boom"
-
-        # When step() raises in ephemeral mode without a failure_msg
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step("warming caches", ephemeral=True),
-        ):
-            raise RuntimeError(err_msg)
-
-        # Then the original message appears in the surfaced error output
-        text = err.export_text()
-        assert "warming caches" in text
-
-    def test_ephemeral_failure_preserves_failure_msg_styling(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-    ) -> None:
-        """Verify ephemeral failure preserves Rich markup styling in failure_msg."""
-        # Given an emitter wired to recording stderr
-        e, _, err = make_recording_emitter()
-        err_msg = "boom"
-
-        # When step() raises ephemerally with a styled failure_msg
-        styled = Text("cache priming failed", style="bold red")
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step("warming", ephemeral=True, failure_msg=styled),
-        ):
-            raise RuntimeError(err_msg)
-
-        # Then the styled fragment appears in the recorded HTML output with styling preserved
-        html = err.export_html()
-        assert "cache priming failed" in html
-        # The styling marker should be present (red color or bold weight)
-        assert "color: " in html or "font-weight" in html
-
 
 class TestModuleLevelStep:
     """Module-level `step()` forwards override kwargs to the default emitter."""
@@ -276,31 +147,9 @@ class TestModuleLevelStep:
         text = out.export_text()
         assert "compiled 42 files" in text
 
-    def test_module_step_accepts_failure_msg(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        isolated_default: None,
-    ) -> None:
-        """Verify the module-level step() forwards failure_msg to the default emitter."""
-        # Given the default emitter is replaced with a recording one
-        e, out, _ = make_recording_emitter()
-        pp_emitter.set_default(e)
-        err_msg = "boom"
-
-        # When the module-level step() raises with a failure_msg override
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            pp_emitter.step("compiling", failure_msg="compilation aborted"),
-        ):
-            raise RuntimeError(err_msg)
-
-        # Then the override message appears in the rendered output
-        text = out.export_text()
-        assert "compilation aborted" in text
-
 
 class TestMarkupAppliesToOverrides:
-    """`markup=True` parses Rich markup in success_msg and failure_msg."""
+    """`markup=True` parses Rich markup in success_msg."""
 
     def test_markup_true_parses_success_msg(
         self, make_recording_emitter: RecordingEmitterFactory
@@ -316,26 +165,6 @@ class TestMarkupAppliesToOverrides:
         # Then the rendered output contains the message text but not the literal markup tags
         text = out.export_text()
         assert "compiled all" in text
-        assert "[bold]" not in text
-
-    def test_markup_true_parses_failure_msg(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify markup=True parses Rich markup tags in failure_msg."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-        err_msg = "boom"
-
-        # When step() raises with a markup-containing override and markup=True
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step("compiling", failure_msg="[bold]aborted[/]", markup=True),
-        ):
-            raise RuntimeError(err_msg)
-
-        # Then the rendered output contains the message text but not the literal markup tags
-        text = out.export_text()
-        assert "aborted" in text
         assert "[bold]" not in text
 
 
@@ -423,381 +252,6 @@ class TestSetSuccessFromBlock:
         text = out.export_text()
         assert "compiled 42 files" in text
 
-    def test_set_success_ignored_on_failure(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_success() has no effect when the block raises."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-        err_msg = "boom"
-
-        # When set_success() is called and then an exception is raised
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling") as s:
-            s.set_success("compiled 42 files")
-            raise RuntimeError(err_msg)
-
-        # Then the success setter value does not surface in the failure output
-        text = out.export_text()
-        assert "compiled 42 files" not in text
-
-
-class TestSetFailureFromBlock:
-    """`Step.set_failure()` updates the failure header from inside the block."""
-
-    def test_set_failure_replaces_header(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_failure() applied inside the block replaces the failure header."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-        err_msg = "boom"
-
-        # When the block sets a contingent failure message before raising
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling") as s:
-            s.set_failure("failed after 17 files")
-            raise RuntimeError(err_msg)
-
-        # Then the dynamic failure message appears in the rendered output
-        text = out.export_text()
-        assert "failed after 17 files" in text
-
-    def test_set_failure_overrides_kwarg(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_failure() takes precedence over the failure_msg kwarg."""
-        # Given an emitter with a kwarg-provided failure_msg
-        e, out, _ = make_recording_emitter()
-        err_msg = "boom"
-
-        # When set_failure() overrides it from inside the block
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step("compiling", failure_msg="kwarg failure") as s,
-        ):
-            s.set_failure("setter failure")
-            raise RuntimeError(err_msg)
-
-        # Then the setter's message appears and the kwarg's does not
-        text = out.export_text()
-        assert "setter failure" in text
-        assert "kwarg failure" not in text
-
-    def test_set_failure_in_logfile(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify set_failure() value is recorded in the failed: log line."""
-        # Given an emitter with a logfile
-        logfile = tmp_path / "run.log"
-        e, _, _ = make_recording_emitter(logfile=logfile)
-        err_msg = "boom"
-
-        # When set_failure() is used and the block raises
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling") as s:
-            s.set_failure("failed after 17 files")
-            raise RuntimeError(err_msg)
-
-        # Then the logfile records the setter message
-        contents = logfile.read_text()
-        assert "failed: failed after 17 files" in contents
-
-    def test_set_failure_ephemeral_surfaces_on_stderr(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_failure() under ephemeral=True surfaces on stderr."""
-        # Given an emitter wired to recording stderr
-        e, _, err = make_recording_emitter()
-        err_msg = "boom"
-
-        # When an ephemeral step sets a failure message and raises
-        with (
-            pytest.raises(RuntimeError, match=err_msg),
-            e.step("warming caches", ephemeral=True) as s,
-        ):
-            s.set_failure("cache priming failed at item 17")
-            raise RuntimeError(err_msg)
-
-        # Then the setter's failure message appears on stderr
-        text = err.export_text()
-        assert "cache priming failed at item 17" in text
-
-    def test_set_failure_markup_parses_tags(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_failure(markup=True) parses Rich markup in the message."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-        err_msg = "boom"
-
-        # When set_failure() is invoked with markup=True before raising
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling") as s:
-            s.set_failure("[bold]aborted hard[/]", markup=True)
-            raise RuntimeError(err_msg)
-
-        # Then the rendered output contains the message text without literal tags
-        text = out.export_text()
-        assert "aborted hard" in text
-        assert "[bold]" not in text
-
-    def test_set_failure_ignored_on_success(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify set_failure() has no effect when the block completes normally."""
-        # Given an emitter with logfile
-        logfile = tmp_path / "run.log"
-        e, out, _ = make_recording_emitter(logfile=logfile)
-
-        # When set_failure() is called but the block succeeds
-        with e.step("compiling") as s:
-            s.set_failure("would-be failure")
-
-        # Then the failure setter value does not surface in success output or log
-        text = out.export_text()
-        assert "would-be failure" not in text
-        assert "would-be failure" not in logfile.read_text()
-
-
-class TestStepSkipMsg:
-    """`skip_msg` kwarg supplies the default text used when `set_skipped()` fires."""
-
-    def test_skip_msg_displays_when_set_skipped_called_no_args(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify skip_msg kwarg supplies the header when set_skipped() is called without args."""
-        # Given an emitter wired to a recording console
-        e, out, _ = make_recording_emitter()
-
-        # When step() runs and set_skipped() fires with no message
-        with e.step("compiling", skip_msg="nothing to compile") as s:
-            s.set_skipped()
-
-        # Then the kwarg message appears in the rendered output
-        text = out.export_text()
-        assert "nothing to compile" in text
-
-    def test_skip_msg_falls_back_to_original_message(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_skipped() with no kwarg/arg uses the original step message."""
-        # Given an emitter and a step with no skip_msg
-        e, out, _ = make_recording_emitter()
-
-        # When set_skipped() fires without overrides
-        with e.step("compiling") as s:
-            s.set_skipped()
-
-        # Then the original message appears in the rendered output
-        text = out.export_text()
-        assert "compiling" in text
-
-    def test_skip_msg_records_skipped_in_logfile(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify the logfile records a `skipped:` line when the step is skipped."""
-        # Given an emitter with a logfile
-        logfile = tmp_path / "run.log"
-        e, _, _ = make_recording_emitter(logfile=logfile)
-
-        # When the block marks itself skipped with a kwarg message
-        with e.step("compiling", skip_msg="nothing to compile") as s:
-            s.set_skipped()
-
-        # Then the logfile records the skipped: line with the kwarg message
-        contents = logfile.read_text()
-        assert "skipped: nothing to compile" in contents
-        # And it should not record a succeeded: or failed: line
-        assert "succeeded:" not in contents
-        assert "failed:" not in contents
-
-    def test_skip_msg_kwarg_alone_does_not_trigger_skip(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify skip_msg kwarg without set_skipped() leaves the step on the success path."""
-        # Given an emitter with a logfile and a skip_msg kwarg
-        logfile = tmp_path / "run.log"
-        e, out, _ = make_recording_emitter(logfile=logfile)
-
-        # When the block exits normally without calling set_skipped()
-        with e.step("compiling", skip_msg="would skip"):
-            pass
-
-        # Then the step records as succeeded and skip_msg does not surface
-        contents = logfile.read_text()
-        assert "succeeded: compiling" in contents
-        assert "skipped:" not in contents
-        assert "would skip" not in out.export_text()
-
-
-class TestSetSkippedFromBlock:
-    """`Step.set_skipped()` marks the step as skipped from inside the block."""
-
-    def test_set_skipped_with_message_replaces_header(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_skipped("msg") applied inside the block replaces the completion header."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-
-        # When the block decides to skip with an inline message
-        with e.step("compiling") as s:
-            s.set_skipped("no source files found")
-
-        # Then the inline message appears in the rendered output
-        text = out.export_text()
-        assert "no source files found" in text
-
-    def test_set_skipped_overrides_kwarg(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_skipped(message) takes precedence over the skip_msg kwarg."""
-        # Given an emitter with a kwarg-provided skip_msg
-        e, out, _ = make_recording_emitter()
-
-        # When set_skipped() overrides it from inside the block
-        with e.step("compiling", skip_msg="kwarg skip") as s:
-            s.set_skipped("setter skip")
-
-        # Then the setter's message appears and the kwarg's does not
-        text = out.export_text()
-        assert "setter skip" in text
-        assert "kwarg skip" not in text
-
-    def test_set_skipped_in_logfile(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify set_skipped() message is recorded in the `skipped:` log line."""
-        # Given an emitter with a logfile
-        logfile = tmp_path / "run.log"
-        e, _, _ = make_recording_emitter(logfile=logfile)
-
-        # When set_skipped() is used inside the block
-        with e.step("compiling") as s:
-            s.set_skipped("no source files found")
-
-        # Then the logfile records the setter message under `skipped:`
-        contents = logfile.read_text()
-        assert "skipped: no source files found" in contents
-
-    def test_set_skipped_uses_info_styling_not_success(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify the skipped completion does not use the success checkmark marker."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-
-        # When the block marks itself skipped
-        with e.step("compiling") as s:
-            s.set_skipped("no source files")
-
-        # Then the rendered output does not contain the success marker glyph
-        text = out.export_text()
-        assert "no source files" in text
-        # Success glyph (unicode or ASCII fallback) must not appear
-        assert "✓" not in text
-        assert "+ no source files" not in text
-
-    def test_set_skipped_markup_parses_tags(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_skipped(markup=True) parses Rich markup in the message."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-
-        # When the setter is invoked with markup=True
-        with e.step("compiling") as s:
-            s.set_skipped("[bold]nothing to do[/]", markup=True)
-
-        # Then the rendered output contains the message text without literal tags
-        text = out.export_text()
-        assert "nothing to do" in text
-        assert "[bold]" not in text
-
-    def test_set_skipped_accepts_renderable(
-        self, make_recording_emitter: RecordingEmitterFactory
-    ) -> None:
-        """Verify set_skipped() accepts an arbitrary Rich renderable."""
-        # Given an emitter
-        e, out, _ = make_recording_emitter()
-
-        # When a Padding renderable is supplied
-        with e.step("compiling") as s:
-            s.set_skipped(Padding("no work to do", (0, 1)))
-
-        # Then the renderable's text appears in the rendered output
-        text = out.export_text()
-        assert "no work to do" in text
-
-    def test_set_skipped_ignored_on_failure(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify set_skipped() has no effect when the block raises (failure path wins)."""
-        # Given an emitter with a logfile
-        logfile = tmp_path / "run.log"
-        e, _, _ = make_recording_emitter(logfile=logfile)
-        err_msg = "boom"
-
-        # When set_skipped() is called and then an exception is raised
-        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling") as s:
-            s.set_skipped("would skip")
-            raise RuntimeError(err_msg)
-
-        # Then the logfile records `failed:`, not `skipped:`
-        contents = logfile.read_text()
-        assert "failed: compiling" in contents
-        assert "skipped:" not in contents
-
-    def test_set_skipped_ephemeral_clears_console_but_logs(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        tmp_path: Path,
-    ) -> None:
-        """Verify ephemeral skip wipes the console output but records skipped: in logfile."""
-        # Given an emitter with logfile and an ephemeral step
-        logfile = tmp_path / "run.log"
-        e, out, _ = make_recording_emitter(logfile=logfile)
-
-        # When the block marks itself skipped under ephemeral=True
-        with e.step("warming caches", ephemeral=True, skip_msg="caches already warm") as s:
-            s.set_skipped()
-
-        # Then the console is clean of skip text (ephemeral wipes the marker)
-        # but the logfile records the skip
-        assert "caches already warm" not in out.export_text()
-        assert "skipped: caches already warm" in logfile.read_text()
-
-
-class TestModuleLevelStepSkip:
-    """Module-level `step()` forwards `skip_msg` to the default emitter."""
-
-    def test_module_step_accepts_skip_msg(
-        self,
-        make_recording_emitter: RecordingEmitterFactory,
-        isolated_default: None,
-    ) -> None:
-        """Verify the module-level step() forwards skip_msg to the default emitter."""
-        # Given the default emitter is replaced with a recording one
-        e, out, _ = make_recording_emitter()
-        pp_emitter.set_default(e)
-
-        # When the module-level step() runs and the block calls set_skipped()
-        with pp_emitter.step("compiling", skip_msg="nothing to compile") as s:
-            s.set_skipped()
-
-        # Then the kwarg message appears in the rendered output
-        text = out.export_text()
-        assert "nothing to compile" in text
-
 
 class TestStepFail:
     """`Step.fail()` exits the block with failure outcome."""
@@ -864,7 +318,7 @@ class TestStepFail:
         err_msg = "bad input"
         with e.step("compiling") as s:
             try:
-                raise ValueError(err_msg)  # noqa: TRY301
+                raise ValueError(err_msg)
             except ValueError as caught:
                 s.fail("compilation failed", exception=caught)
 
@@ -1004,3 +458,97 @@ class TestStepSkip:
         # Then a TypeError is raised
         with pytest.raises(TypeError), e.step("warming caches") as s:
             s.skip()  # type: ignore[call-arg]
+
+
+class TestStepUncaughtException:
+    """An uncaught exception inside step() propagates cleanly with no marker and no log line."""
+
+    def test_uncaught_exception_propagates(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify an unhandled exception inside the block still propagates to the caller."""
+        # Given an emitter
+        e, _, _ = make_recording_emitter()
+        err_msg = "boom"
+
+        # When the block raises and nothing catches it
+        # Then the exception is re-raised by the context manager
+        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling"):
+            raise RuntimeError(err_msg)
+
+    def test_uncaught_exception_writes_no_log_line(
+        self,
+        make_recording_emitter: RecordingEmitterFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Verify step() writes no failed:/succeeded:/skipped: line on an uncaught exception."""
+        # Given an emitter with a logfile
+        logfile = tmp_path / "run.log"
+        e, _, _ = make_recording_emitter(logfile=logfile)
+        err_msg = "boom"
+
+        # When the block raises
+        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling"):
+            raise RuntimeError(err_msg)
+
+        # Then the logfile has the `starting:` line but no completion line
+        contents = logfile.read_text()
+        assert "starting: compiling" in contents
+        assert "failed:" not in contents
+        assert "succeeded:" not in contents
+        assert "skipped:" not in contents
+
+    def test_uncaught_exception_renders_no_error_marker(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify the rendered output contains no error marker glyph on uncaught exception."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+        err_msg = "boom"
+
+        # When the block raises
+        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling"):
+            raise RuntimeError(err_msg)
+
+        # Then no failure marker appears in the rendered output
+        text = out.export_text()
+        assert "✗" not in text  # unicode error marker
+        assert "compiling" in text  # original message still visible (neutralized header)
+
+    def test_uncaught_exception_ephemeral_emits_nothing_extra(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify ephemeral=True wipes everything and emits no fresh stderr line on uncaught exception."""
+        # Given an emitter
+        e, _, err = make_recording_emitter()
+        err_msg = "boom"
+
+        # When an ephemeral step's body raises
+        with (
+            pytest.raises(RuntimeError, match=err_msg),
+            e.step("warming caches", ephemeral=True),
+        ):
+            raise RuntimeError(err_msg)
+
+        # Then no fresh error line is produced on stderr (caller owns error reporting)
+        err_text = err.export_text()
+        assert "warming caches" not in err_text
+
+    def test_subitems_remain_visible_after_uncaught_exception(
+        self, make_recording_emitter: RecordingEmitterFactory
+    ) -> None:
+        """Verify sub-items added before the exception remain in the non-ephemeral output."""
+        # Given an emitter
+        e, out, _ = make_recording_emitter()
+        err_msg = "boom"
+
+        # When sub-items are added then the block raises
+        with pytest.raises(RuntimeError, match=err_msg), e.step("compiling") as s:
+            s.sub("src/a.py")
+            s.sub("src/b.py")
+            raise RuntimeError(err_msg)
+
+        # Then the sub-items appear in the rendered output
+        text = out.export_text()
+        assert "src/a.py" in text
+        assert "src/b.py" in text

--- a/tests/pp/test_step_msgs.py
+++ b/tests/pp/test_step_msgs.py
@@ -168,85 +168,85 @@ class TestMarkupAppliesToOverrides:
         assert "[bold]" not in text
 
 
-class TestSetSuccessFromBlock:
-    """`Step.set_success()` updates the success header from inside the block."""
+class TestSetSuccessMsgFromBlock:
+    """`Step.set_success_msg()` updates the success header from inside the block."""
 
-    def test_set_success_replaces_header(
+    def test_set_success_msg_replaces_header(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify set_success() applied inside the block replaces the success header."""
+        """Verify set_success_msg() applied inside the block replaces the success header."""
         # Given an emitter
         e, out, _ = make_recording_emitter()
 
-        # When the block computes a result and applies it via set_success
+        # When the block computes a result and applies it via set_success_msg
         with e.step("compiling") as s:
             count = 42
-            s.set_success(f"compiled {count} files")
+            s.set_success_msg(f"compiled {count} files")
 
         # Then the dynamic message appears in the rendered output
         text = out.export_text()
         assert "compiled 42 files" in text
 
-    def test_set_success_overrides_kwarg(
+    def test_set_success_msg_overrides_kwarg(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify set_success() takes precedence over the success_msg kwarg."""
+        """Verify set_success_msg() takes precedence over the success_msg kwarg."""
         # Given an emitter with a kwarg-provided success_msg
         e, out, _ = make_recording_emitter()
 
-        # When set_success() overrides it from inside the block
+        # When set_success_msg() overrides it from inside the block
         with e.step("compiling", success_msg="kwarg wins?") as s:
-            s.set_success("setter wins")
+            s.set_success_msg("setter wins")
 
         # Then the setter's message appears and the kwarg's does not
         text = out.export_text()
         assert "setter wins" in text
         assert "kwarg wins" not in text
 
-    def test_set_success_in_logfile(
+    def test_set_success_msg_in_logfile(
         self,
         make_recording_emitter: RecordingEmitterFactory,
         tmp_path: Path,
     ) -> None:
-        """Verify set_success() value is recorded in the succeeded: log line."""
+        """Verify set_success_msg() value is recorded in the succeeded: log line."""
         # Given an emitter with a logfile
         logfile = tmp_path / "run.log"
         e, _, _ = make_recording_emitter(logfile=logfile)
 
-        # When set_success() is used inside the block
+        # When set_success_msg() is used inside the block
         with e.step("compiling") as s:
-            s.set_success("compiled 42 files")
+            s.set_success_msg("compiled 42 files")
 
         # Then the logfile records the setter message
         contents = logfile.read_text()
         assert "succeeded: compiled 42 files" in contents
 
-    def test_set_success_markup_parses_tags(
+    def test_set_success_msg_markup_parses_tags(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify set_success(markup=True) parses Rich markup in the message."""
+        """Verify set_success_msg(markup=True) parses Rich markup in the message."""
         # Given an emitter
         e, out, _ = make_recording_emitter()
 
         # When the setter is invoked with markup=True
         with e.step("compiling") as s:
-            s.set_success("[bold]all done[/]", markup=True)
+            s.set_success_msg("[bold]all done[/]", markup=True)
 
         # Then the rendered output contains the message text without literal tags
         text = out.export_text()
         assert "all done" in text
         assert "[bold]" not in text
 
-    def test_set_success_accepts_renderable(
+    def test_set_success_msg_accepts_renderable(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
-        """Verify set_success() accepts an arbitrary Rich renderable."""
+        """Verify set_success_msg() accepts an arbitrary Rich renderable."""
         # Given an emitter
         e, out, _ = make_recording_emitter()
 
         # When a Padding renderable is supplied
         with e.step("compiling") as s:
-            s.set_success(Padding("compiled 42 files", (0, 1)))
+            s.set_success_msg(Padding("compiled 42 files", (0, 1)))
 
         # Then the renderable's text appears in the rendered output
         text = out.export_text()

--- a/tests/pp/test_theme.py
+++ b/tests/pp/test_theme.py
@@ -349,17 +349,16 @@ class TestThemeAppliedToOutput:
         assert "compiling" in text
         assert "✓" not in text
 
-    def test_step_renders_custom_error_marker_on_exception(
+    def test_step_renders_custom_error_marker_on_fail(
         self, make_recording_emitter: RecordingEmitterFactory
     ) -> None:
         """Verify step()'s failure completion uses the error.marker override."""
         # Given an Emitter with error.marker overridden
         e, out, _ = make_recording_emitter(theme=Theme(error=Level(marker="💥 ")))
 
-        # When a step block raises an exception
-        err_msg = "boom"
-        with pytest.raises(RuntimeError), e.step("compiling"):
-            raise RuntimeError(err_msg)
+        # When a step block exits via s.fail()
+        with e.step("compiling") as s:
+            s.fail("aborted")
 
         # Then the custom error marker appears and the default ✗ does not
         text = out.export_text()


### PR DESCRIPTION
## Summary

- Replaces `pp.step()`'s auto-exception-to-failure path with caller-owned outcome control. New `Step.fail()` / `Step.skip()` methods exit the block via an internal `_StepExit` sentinel.
- Renames `Step.set_success` to `Step.set_success_msg` to signal "override-only, does not exit." Removes `Step.set_failure`, `Step.set_skipped`, and the `failure_msg=` / `skip_msg=` kwargs.
- Uncaught exceptions inside `step()` now propagate cleanly with the spinner replaced by a plain static line. No marker, no log line. The caller owns error reporting.

## Breaking changes

- `Step.set_success` -> `Step.set_success_msg` (same semantics, clearer name)
- `Step.set_failure` -> `Step.fail(msg)` (now **exits** the block)
- `Step.set_skipped` -> `Step.skip(msg)` (now **exits** the block)
- `step(failure_msg=...)` and `step(skip_msg=...)` kwargs removed
- Uncaught exceptions no longer render a failure marker or write a `failed:` log line; callers must call `s.fail(...)` explicitly for that

## Test plan

- [ ] Full test suite passes (`uv run pytest` reports 614 / 614)
- [ ] Lint clean (`duty lint`)
- [ ] Manual smoke: `s.fail("...")` renders the error marker and writes a `failed:` log line in both ephemeral and non-ephemeral modes
- [ ] Manual smoke: `s.skip("...")` renders the info marker and writes a `skipped:` log line
- [ ] Manual smoke: uncaught exception leaves the original message visible with sub-items intact, no marker, no log line
- [ ] Manual smoke: `s.fail(exception=e)` attaches the exception type/message to the `failed:` log line as a continuation